### PR TITLE
Permit tag names in --restore_from flag.

### DIFF
--- a/deeplearning/ml4pl/models/checkpoints_test.py
+++ b/deeplearning/ml4pl/models/checkpoints_test.py
@@ -22,6 +22,27 @@ from labm8.py import test
 FLAGS = test.FLAGS
 
 
+def CheckpointReference_from_tag_without_epoch_num():
+  c = checkpoints.CheckpointReference.FromString("my_tag")
+  assert c.run_id is None
+  assert c.tag == "my_tag"
+  assert c.epoch_num is None
+
+
+def CheckpointReference_from_tag_with_epoch_num():
+  c = checkpoints.CheckpointReference.FromString("my_tag@5")
+  assert c.run_id is None
+  assert c.tag == "my_tag"
+  assert c.epoch_num == 5
+
+
+def CheckpointReference_from_tag_with_best_epoch_num():
+  c = checkpoints.CheckpointReference.FromString("my_tag@best")
+  assert c.run_id is None
+  assert c.tag == "my_tag"
+  assert c.epoch_num is None
+
+
 def CheckpointReference_without_epoch_num():
   """Check construction of a checkpoint reference without epoch number."""
   run_id = run_id_lib.RunId.GenerateUnique("reftest")

--- a/deeplearning/ml4pl/models/classifier_base.py
+++ b/deeplearning/ml4pl/models/classifier_base.py
@@ -230,6 +230,7 @@ class ClassifierBase(object):
     epoch_type: epoch.Type,
     batch_iterator: batches.BatchIterator,
     logger: logging.Logger,
+    epoch_name_prefix: str = "",
   ) -> epoch.Results:
     """Run the model for over the input batches.
 
@@ -246,6 +247,7 @@ class ClassifierBase(object):
       epoch_type: The type of epoch to run.
       batch_iterator: The batches to process.
       logger: A logger instance to log results to.
+      epoch_name_prefix: An optional prefix for the name of the epoch.
 
     Returns:
       An epoch results instance.
@@ -259,7 +261,13 @@ class ClassifierBase(object):
     if epoch_type == epoch.Type.TRAIN:
       self.epoch_num += 1
 
-    thread = EpochThread(self, epoch_type, batch_iterator, logger)
+    thread = EpochThread(
+      self,
+      epoch_type,
+      batch_iterator,
+      logger,
+      epoch_name_prefix=epoch_name_prefix,
+    )
     progress.Run(thread)
 
     # Check that there were batches.
@@ -421,6 +429,7 @@ class EpochThread(progress.Progress):
     epoch_type: epoch.Type,
     batch_iterator: batches.BatchIterator,
     logger: logging.Logger,
+    epoch_name_prefix: str = "",
   ):
     """Constructor.
 
@@ -441,9 +450,12 @@ class EpochThread(progress.Progress):
     self.graph_ids = set()
 
     super(EpochThread, self).__init__(
-      f"{epoch_type.name.capitalize()} epoch {model.epoch_num}",
-      0,
-      batch_iterator.graph_count,
+      name=(
+        f"{epoch_name_prefix}{epoch_type.name.capitalize()} "
+        f"epoch {model.epoch_num}"
+      ),
+      i=0,
+      n=batch_iterator.graph_count,
       unit="graph",
       vertical_position=0,
       leave=False,

--- a/deeplearning/ml4pl/models/classifier_base.py
+++ b/deeplearning/ml4pl/models/classifier_base.py
@@ -400,7 +400,7 @@ class ClassifierBase(object):
       )
     )
     return checkpoints.CheckpointReference(
-      run_id=self.run_id, epoch_num=self.epoch_num
+      run_id=self.run_id, tag=None, epoch_num=self.epoch_num
     )
 
   @decorators.memoized_property


### PR DESCRIPTION
This extends the CheckpointReference class to contain *either* a
run ID, or the name of a tag. When a tag is used, it is resolved
to one or more run IDs during Logger.Load(), and supports both
loading the checkpoint with the best validation accuracy, or a
model at a specific epoch number, where an epoch number references
only a single run.