### PR TITLE
ml4pl: Fix global run ID

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -75,18 +75,6 @@ python_grpc_library(
     deps = ["//:config_pb"],
 )
 
-py_library(
-    name = "conftest",
-    testonly = 1,
-    srcs = ["conftest.py"],
-    visibility = ["//visibility:public"],
-    deps = [
-        "//:build_info",
-        "//labm8/py:app",
-        "//third_party/py/pytest",
-    ],
-)
-
 # Golang.
 # Gazelle directive:
 # gazelle:prefix github.com/ChrisCummins/phd

--- a/deeplearning/ml4pl/BUILD
+++ b/deeplearning/ml4pl/BUILD
@@ -64,3 +64,12 @@ py_test(
         "//third_party/py/sqlalchemy",
     ],
 )
+
+py_test(
+    name = "run_id_multiprocess_test",
+    srcs = ["run_id_multiprocess_test.py"],
+    deps = [
+        ":run_id",
+        "//labm8/py:test",
+    ],
+)

--- a/deeplearning/ml4pl/BUILD
+++ b/deeplearning/ml4pl/BUILD
@@ -57,7 +57,6 @@ py_binary(
 py_test(
     name = "run_id_test",
     srcs = ["run_id_test.py"],
-    shard_count = 3,
     deps = [
         ":run_id",
         "//labm8/py:sqlutil",

--- a/deeplearning/ml4pl/graphs/labelled/dataflow/BUILD
+++ b/deeplearning/ml4pl/graphs/labelled/dataflow/BUILD
@@ -55,6 +55,7 @@ py_test(
     size = "enormous",
     timeout = "eternal",
     srcs = ["annotators_benchmark_test.py"],
+    args = ["--pytest_args=--benchmark-warmup-iterations=2"],
     deps = [
         ":annotate",
         ":data_flow_graphs",

--- a/deeplearning/ml4pl/graphs/labelled/dataflow/annotators_benchmark_test.py
+++ b/deeplearning/ml4pl/graphs/labelled/dataflow/annotators_benchmark_test.py
@@ -24,8 +24,6 @@ FLAGS = test.FLAGS
 
 MODULE_UNDER_TEST = None
 
-PYTEST_ARGS = ["--benchmark-warmup-iterations=2"]
-
 # Real programs to test over.
 PROTOS = list(random_programl_generator.EnumerateTestSet(n=20))
 

--- a/deeplearning/ml4pl/run_id.py
+++ b/deeplearning/ml4pl/run_id.py
@@ -161,6 +161,11 @@ class RunId(NamedTuple):
 
     script_name = pathlib.Path(sys.argv[0]).stem
 
+    # Correct the script name when running from the command line,
+    # e.g. 'python -c "<cmd>"'.
+    if script_name == "-c":
+      script_name = "python"
+
     return cls.GenerateUnique(script_name)
 
   @classmethod

--- a/deeplearning/ml4pl/run_id_multiprocess_test.py
+++ b/deeplearning/ml4pl/run_id_multiprocess_test.py
@@ -1,0 +1,66 @@
+# Copyright 2019 the ProGraML authors.
+#
+# Contact Chris Cummins <chrisc.101@gmail.com>.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Multi-processing tests for //deeplearning/ml4pl:run_id."""
+import multiprocessing
+import subprocess
+import sys
+
+from deeplearning.ml4pl import run_id
+from labm8.py import test
+
+
+FLAGS = test.FLAGS
+
+
+def _MakeARunId(*args):
+  """Generate a run ID."""
+  return run_id.RunId.GenerateGlobalUnique()
+
+
+def test_GenerateGlobalUnique_subprocess():
+  """Run IDs should be unique when running as subprocesses."""
+  unique_run_ids = set()
+
+  for _ in range(30):
+    run_id_ = subprocess.check_output(
+      [
+        sys.executable,
+        "-c",
+        "from deeplearning.ml4pl import run_id; "
+        "print(run_id.RunId.GenerateGlobalUnique())",
+      ],
+      universal_newlines=True,
+    )
+
+    if run_id_ in unique_run_ids:
+      test.Fail("Non-unique run ID generated")
+    unique_run_ids.add(run_id_)
+
+
+def test_GenerateGlobalUnique_multiprocessed():
+  """Generate a bunch of run IDs concurrently and check that they are unique."""
+  unique_run_ids = set()
+
+  with multiprocessing.Pool() as p:
+    for run_id_ in p.imap_unordered(_MakeARunId, range(30)):
+      print("Generated run ID:", run_id)
+      if run_id_ in unique_run_ids:
+        test.Fail("Non-unique run ID generated")
+      unique_run_ids.add(run_id_)
+
+
+if __name__ == "__main__":
+  test.Main()

--- a/deeplearning/ml4pl/run_id_test.py
+++ b/deeplearning/ml4pl/run_id_test.py
@@ -15,9 +15,6 @@
 # limitations under the License.
 """Unit tests for //deeplearning/ml4pl:run_id."""
 import datetime
-import multiprocessing
-import subprocess
-import sys
 import time
 
 import sqlalchemy as sql
@@ -126,43 +123,6 @@ def test_GenerateGlobalUnique_unique_timestamps():
     # Check that run ID has changed.
     assert run_id_ != previous_run_id
     previous_run_id = run_id_
-
-
-def _MakeARunId(*args):
-  """Generate a run ID."""
-  return run_id.RunId.GenerateGlobalUnique()
-
-
-def test_GenerateGlobalUnique_subprocess():
-  """Run IDs should be unique when running as subprocesses."""
-  unique_run_ids = set()
-
-  for _ in range(30):
-    run_id_ = subprocess.check_output(
-      [
-        sys.executable,
-        "-c",
-        "from deeplearning.ml4pl import run_id; "
-        "print(run_id.RunId.GenerateGlobalUnique())",
-      ],
-      universal_newlines=True,
-    )
-
-    if run_id_ in unique_run_ids:
-      test.Fail("Non-unique run ID generated")
-    unique_run_ids.add(run_id_)
-
-
-def test_GenerateGlobalUnique_multiprocessed():
-  """Generate a bunch of run IDs concurrently and check that they are unique."""
-  unique_run_ids = set()
-
-  with multiprocessing.Pool() as p:
-    for run_id_ in p.imap_unordered(_MakeARunId, range(30)):
-      print("Generated run ID:", run_id)
-      if run_id_ in unique_run_ids:
-        test.Fail("Non-unique run ID generated")
-      unique_run_ids.add(run_id_)
 
 
 if __name__ == "__main__":

--- a/labm8/py/BUILD
+++ b/labm8/py/BUILD
@@ -709,7 +709,7 @@ py_library(
     visibility = ["//visibility:public"],
     deps = [
         ":app",
-        "//:conftest",
+        "//labm8/py/internal:pytest_plugin",
         "//third_party/py/pytest",
     ],
 )

--- a/labm8/py/internal/BUILD
+++ b/labm8/py/internal/BUILD
@@ -55,3 +55,15 @@ python_proto_library(
     visibility = ["//labm8/py:__subpackages__"],
     deps = [":logging_pb"],
 )
+
+py_library(
+    name = "pytest_plugin",
+    testonly = 1,
+    srcs = ["pytest_plugin.py"],
+    visibility = ["//labm8/py:__subpackages__"],
+    deps = [
+        "//:build_info",
+        "//labm8/py:app",
+        "//third_party/py/pytest",
+    ],
+)

--- a/labm8/py/internal/pytest_plugin.py
+++ b/labm8/py/internal/pytest_plugin.py
@@ -1,4 +1,4 @@
-"""Repo-wide pytest configuration and test fixtures."""
+"""This module defines a pytest plugin for labm8."""
 import pathlib
 import socket
 import sys

--- a/labm8/py/internal/pytest_plugin.py
+++ b/labm8/py/internal/pytest_plugin.py
@@ -64,6 +64,17 @@ PLATFORM_NAMES = set("darwin linux win32".split())
 HOST_NAMES = set("diana florence".split())
 
 
+def pytest_configure(config):
+  """Programatic configuration of pytest."""
+  # Register the custom markers used by labm8.
+  config.addinivalue_line("markers", "slow")
+  config.addinivalue_line("markers", "darwin")
+  config.addinivalue_line("markers", "linux")
+  config.addinivalue_line("markers", "win32")
+  config.addinivalue_line("markers", "diana")
+  config.addinivalue_line("markers", "florence")
+
+
 def pytest_collection_modifyitems(config, items):
   """A pytest hook to modify the configuration and items to run."""
   del config

--- a/labm8/py/internal/pytest_plugin.py
+++ b/labm8/py/internal/pytest_plugin.py
@@ -134,7 +134,7 @@ def pytest_collection_modifyitems(config, items):
     supported_platforms = PLATFORM_NAMES.intersection(item.keywords)
     if supported_platforms and this_platform not in supported_platforms:
       skip_msg = f"Skipping `{item.name}` for platforms: {supported_platforms}"
-      app.Log(1, skip_msg)
+      print(skip_msg)
       item.add_marker(pytest.mark.skip(reason=skip_msg))
       continue
 
@@ -142,7 +142,7 @@ def pytest_collection_modifyitems(config, items):
     supported_hosts = HOST_NAMES.intersection(item.keywords)
     if supported_hosts and this_host not in supported_hosts:
       skip_msg = f"Skipping `{item.name}` for hosts: {supported_hosts}"
-      app.Log(1, skip_msg)
+      print(skip_msg)
       item.add_marker(pytest.mark.skip(reason=skip_msg))
       continue
 

--- a/labm8/py/test.py
+++ b/labm8/py/test.py
@@ -126,8 +126,9 @@ def GuessModuleUnderTest(test_module, file_path: str) -> typing.Optional[str]:
 def CoverageContext(
   test_module, file_path: str, pytest_args: typing.List[str],
 ) -> typing.List[str]:
-  # No test coverage requested.
+  # No test coverage requested, disable pytest-cov plugin.
   if not FLAGS.test_coverage:
+    pytest_args += ["-p", "no:cov"]
     yield pytest_args
     return
 
@@ -258,6 +259,8 @@ def RunPytestOnFileAndExit(
     num_shards = int(os.environ["TEST_TOTAL_SHARDS"])
     shard_index = int(os.environ["TEST_SHARD_INDEX"])
     pytest_args += [f"--shard-id={shard_index}", f"--num-shards={num_shards}"]
+  else:
+    pytest_args += ["-p", "no:pytest-shard"]
 
   # Load the test module so that we can inspect it for attributes.
   spec = importutil.spec_from_file_location("module", file_path)

--- a/labm8/py/test.py
+++ b/labm8/py/test.py
@@ -263,11 +263,6 @@ def RunPytestOnFileOrDie(file_path: str, capture_output: bool = None):
   # Add the --pytest_args requested by the user.
   pytest_args += FLAGS.pytest_args
 
-  # Allow the user to add a PYTEST_ARGS = ['--foo'] list of additional
-  # arguments.
-  if hasattr(test_module, "PYTEST_ARGS"):
-    pytest_args += test_module.PYTEST_ARGS
-
   with CoverageContext(test_module, file_path, pytest_args) as pytest_args:
     app.Log(1, "Running pytest with arguments: %s", pytest_args)
     ret = pytest.main(pytest_args)

--- a/labm8/py/test.py
+++ b/labm8/py/test.py
@@ -276,8 +276,10 @@ def RunPytestOnFileOrDie(file_path: str, capture_output: bool = None):
       ret == pytest.ExitCode.NO_TESTS_COLLECTED.value
       and not FLAGS.error_if_no_tests
     ):
-      app.Warning(
-        "The test suite was empty. Use --error_if_no_tests to make this test fail."
+      print(
+        "WARNING: The test suite was empty. "
+        "Use --error_if_no_tests to make this test fail.",
+        file=sys.stderr,
       )
       ret = 0
 

--- a/labm8/py/test.py
+++ b/labm8/py/test.py
@@ -220,6 +220,10 @@ def RunPytestOnFileOrDie(file_path: str, capture_output: bool = None):
     file_path,
     # Run pytest verbosely.
     "-v",
+    # Enable the labm8 test plugin.
+    "-p",
+    "labm8.py.internal.pytest_plugin",
+    # Let bazel handle caching.
     "-p",
     "no:cacheprovider",
   ]

--- a/labm8/py/test_test.py
+++ b/labm8/py/test_test.py
@@ -18,8 +18,6 @@ import random
 import sys
 import tempfile
 
-import pytest
-
 from labm8.py import app
 from labm8.py import test
 
@@ -85,12 +83,6 @@ def test_mark_flaky_with_expected_exception():
 def test_mark_flaky_with_invalid_expected_exception():
   """Test that only expected_exception triggers a re-run."""
   raise TypeError("woops!")
-
-
-@pytest.mark.custom_marker
-def test_custom_marker():
-  """A test with a custom pytest marker that does nothing."""
-  pass
 
 
 @test.LinuxTest()

--- a/labm8/py/test_test.py
+++ b/labm8/py/test_test.py
@@ -215,5 +215,13 @@ def test_TemporaryEnv():
   assert os.environ["ANIMAL"] == "a dog"
 
 
+def test_XML_OUTPUT_FILE_is_not_set():
+  """Test that XML_OUTPUT_FILE is unset, either because:
+  * we're not in a bazel test environment.
+  * it has been unset by test.RunPytestOnFileOrDie().
+  """
+  assert not os.environ.get("XML_OUTPUT_FILE")
+
+
 if __name__ == "__main__":
   test.Main()


### PR DESCRIPTION
This PR started with the simple goal to fix a single failing test case in `//deeplearning/ml4pl/models:run_id_test`.

![Screenshot from 2020-01-25 18-35-22](https://user-images.githubusercontent.com/1636663/73126119-d5a98880-3fa6-11ea-8f71-6378306afc1d.png)

