### PR TITLE
ml4pl: Add data flow time step limit for train/val/test of GGNN/LSTM

### DIFF
--- a/deeplearning/ml4pl/models/ggnn/ggnn.py
+++ b/deeplearning/ml4pl/models/ggnn/ggnn.py
@@ -97,12 +97,11 @@ app.DEFINE_list(
 )
 
 app.DEFINE_boolean(
-  "limit_max_data_flow_steps_during_training",
-  True,
-  "If set, limit the size of dataflow-annotated graphs used to train and "
-  "validate models to only those with data_flow_steps <= sum(layer_timesteps). "
-  "This has no effect for graph databases with no dataflow annotations, or "
-  "for testing epochs.",
+  "limit_max_data_flow_steps",
+  False,
+  "If set, limit the size of dataflow-annotated graphs used to only those with "
+  "data_flow_steps <= sum(layer_timesteps). This has no effect for graph "
+  "databases with no dataflow annotations.",
 )
 # We assume that position_embeddings exist in every dataset.
 # the flag now only controls whether they are used or not.
@@ -331,13 +330,8 @@ class Ggnn(classifier_base.ClassifierBase):
     filters = filters or []
 
     # Only read graphs with data_flow_steps <= message_passing_step_count if
-    # --limit_max_data_flow_steps_during_training is set and we are not
-    # in a test epoch.
-    if (
-      FLAGS.limit_max_data_flow_steps_during_training
-      and self.graph_db.has_data_flow
-      and (epoch_type == epoch.Type.TRAIN or epoch_type == epoch.Type.VAL)
-    ):
+    # --limit_max_data_flow_steps is set.
+    if FLAGS.limit_max_data_flow_steps and self.graph_db.has_data_flow:
       filters.append(
         lambda: graph_tuple_database.GraphTuple.data_flow_steps
         <= self.message_passing_step_count

--- a/deeplearning/ml4pl/models/ggnn/test/graph_classification_test.py
+++ b/deeplearning/ml4pl/models/ggnn/test/graph_classification_test.py
@@ -56,13 +56,13 @@ def CheckResultsProperties(
 
 
 @test.Parametrize("epoch_type", list(epoch.Type))
-@test.Parametrize("limit_max_data_flow_steps_during_training", (False, True))
+@test.Parametrize("limit_max_data_flow_steps", (False, True))
 def test_graph_classifier_call(
   epoch_type: epoch.Type,
   logger: logging.Logger,
   layer_timesteps: List[str],
   graph_y_graph_db: graph_tuple_database.Database,
-  limit_max_data_flow_steps_during_training: bool,
+  limit_max_data_flow_steps: bool,
   node_text_embedding_type: str,
   unroll_strategy: str,
   log1p_graph_x: bool,
@@ -72,9 +72,7 @@ def test_graph_classifier_call(
   FLAGS.unroll_strategy = unroll_strategy
   FLAGS.layer_timesteps = layer_timesteps
   FLAGS.log1p_graph_x = log1p_graph_x
-  FLAGS.limit_max_data_flow_steps_during_training = (
-    limit_max_data_flow_steps_during_training
-  )
+  FLAGS.limit_max_data_flow_steps = limit_max_data_flow_steps
 
   # Test to handle the unsupported combination of config values.
   if (

--- a/deeplearning/ml4pl/models/ggnn/test/node_classification_test.py
+++ b/deeplearning/ml4pl/models/ggnn/test/node_classification_test.py
@@ -56,7 +56,7 @@ def CheckResultsProperties(
 
 
 @test.Parametrize("epoch_type", list(epoch.Type))
-@test.Parametrize("limit_max_data_flow_steps_during_training", (False, True))
+@test.Parametrize("limit_max_data_flow_steps", (False, True))
 def test_node_classifier_call(
   epoch_type: epoch.Type,
   logger: logging.Logger,
@@ -65,16 +65,14 @@ def test_node_classifier_call(
   node_text_embedding_type,
   unroll_strategy: str,
   log1p_graph_x: bool,
-  limit_max_data_flow_steps_during_training: bool,
+  limit_max_data_flow_steps: bool,
 ):
   """Test running a node classifier."""
   FLAGS.inst2vec_embeddings = node_text_embedding_type
   FLAGS.unroll_strategy = unroll_strategy
   FLAGS.layer_timesteps = layer_timesteps
   FLAGS.log1p_graph_x = log1p_graph_x
-  FLAGS.limit_max_data_flow_steps_during_training = (
-    limit_max_data_flow_steps_during_training
-  )
+  FLAGS.limit_max_data_flow_steps = limit_max_data_flow_steps
 
   # Test to handle the unsupported combination of config values.
   if (


### PR DESCRIPTION
This enables optionally limiting data flow timesteps of test epochs on the GGNN (in addition to train/val), and adds the ability for LSTM runs to also limit data flow timesteps to an arbitrary flag value.