### PR TITLE
ml4pl: Reset llvm2graph to old functionality

### DIFF
--- a/deeplearning/ml4pl/graphs/BUILD
+++ b/deeplearning/ml4pl/graphs/BUILD
@@ -171,3 +171,17 @@ py_test(
         "//labm8/py:test",
     ],
 )
+
+py_test(
+    name = "programl_format_conversion_tests",
+    srcs = ["programl_format_conversion_tests.py"],
+    data = [":programl"],
+    shard_count = 32,
+    deps = [
+        ":programl_pb_py",
+        "//deeplearning/ml4pl/testing/fixtures:llvm_program_graph",
+        "//labm8/py:bazelutil",
+        "//labm8/py:test",
+        "//third_party/py/networkx",
+    ],
+)

--- a/deeplearning/ml4pl/graphs/llvm2graph/BUILD
+++ b/deeplearning/ml4pl/graphs/llvm2graph/BUILD
@@ -128,7 +128,7 @@ cc_library(
     ],
 )
 
-py_library(
+py_binary(
     name = "node_encoder",
     srcs = ["node_encoder.py"],
     data = [
@@ -140,6 +140,7 @@ py_library(
         "//deeplearning/ml4pl/models:__subpackages__",
     ],
     deps = [
+        "//deeplearning/ml4pl/graphs:programl",
         "//deeplearning/ml4pl/graphs:programl_pb_py",
         "//deeplearning/ncc/inst2vec:inst2vec_preprocess",
         "//labm8/py:app",

--- a/deeplearning/ml4pl/graphs/llvm2graph/BUILD
+++ b/deeplearning/ml4pl/graphs/llvm2graph/BUILD
@@ -155,6 +155,9 @@ py_test(
     deps = [
         ":node_encoder",
         "//deeplearning/ml4pl/graphs:programl",
+        "//deeplearning/ml4pl/graphs:programl_pb_py",
+        "//deeplearning/ml4pl/testing/fixtures:llvm_program_graph",
         "//labm8/py:test",
+        "//third_party/py/networkx",
     ],
 )

--- a/deeplearning/ml4pl/graphs/llvm2graph/llvm_graph_builder.cc
+++ b/deeplearning/ml4pl/graphs/llvm2graph/llvm_graph_builder.cc
@@ -81,9 +81,16 @@ labm8::StatusOr<BasicBlockEntryExit> LlvmGraphBuilder::VisitBasicBlock(
 
   // Iterate over the instructions of a basic block in-order.
   for (const llvm::Instruction& instruction : block) {
+#ifdef PROGRAML_FUTURE_NODE_REPRESENTATION
+    // TODO(github.com/ChrisCummins/ProGraML/issues/55): Don't use the entire
+    // text of an instruction (e.g. "%3 = add %1 %2") for statement nodes.
+    const string text = GetInstructionRhs(instruction);
+#else
+    const string text = PrintToString(instruction);
+#endif
+
     // Create the graph node for the instruction.
-    auto statement =
-        AddStatement(GetInstructionRhs(instruction), functionNumber);
+    auto statement = AddStatement(text, functionNumber);
     previousNodeNumber = currentNodeNumber;
     currentNodeNumber = statement.first;
 
@@ -131,6 +138,14 @@ labm8::StatusOr<BasicBlockEntryExit> LlvmGraphBuilder::VisitBasicBlock(
         it->second.push_back({currentNodeNumber, position});
       } else if (const auto* operand =
                      llvm::dyn_cast<llvm::Instruction>(value)) {
+#ifdef PROGRAML_FUTURE_NODE_REPRESENTATION
+        // TODO(github.com/ChrisCummins/ProGraML/issues/55): Set name of the
+        // identifier to the LHS of the instruction.
+        const string identifierText = GetInstructionLhs(*operand);
+#else
+        const string identifierText = "!IDENTIFIER";
+#endif
+
         // We have an instruction operand which itself is another instruction.
         //
         // For example, take the following IR snippet:
@@ -152,7 +167,6 @@ labm8::StatusOr<BasicBlockEntryExit> LlvmGraphBuilder::VisitBasicBlock(
         // To this we create the intermediate data flow node '%2' immediately,
         // but defer adding the edge from the producer instruction, since we may
         // not have visited it yet.
-        const string identifierText = GetInstructionLhs(*operand);
         auto identifier = AddIdentifier(identifierText, functionNumber);
 
         // Connect the data -> consumer.
@@ -342,8 +356,14 @@ labm8::StatusOr<ProgramGraph> LlvmGraphBuilder::Build(
 
   // Create the constants.
   for (const auto& constant : constants_) {
+#ifdef PROGRAML_FUTURE_NODE_REPRESENTATION
+    const string immediateText = PrintToString(*constant.first);
+#else
+    const string immediateText = "!IMMEDIATE";
+#endif
+
     // Create the node for the constant.
-    auto immmediate = AddImmediate(PrintToString(*constant.first));
+    auto immmediate = AddImmediate(immediateText);
     // Create data in-flow edges.
     for (auto destination : constant.second) {
       AddDataEdge(immmediate.first, destination.first, destination.second);

--- a/deeplearning/ml4pl/graphs/llvm2graph/llvm_graph_builder.cc
+++ b/deeplearning/ml4pl/graphs/llvm2graph/llvm_graph_builder.cc
@@ -126,16 +126,9 @@ labm8::StatusOr<BasicBlockEntryExit> LlvmGraphBuilder::VisitBasicBlock(
         // will be produced provide the information we want to capture.
       } else if (const auto* constant = llvm::dyn_cast<llvm::Constant>(value)) {
         // If the operand is a constant value, insert a new entry into the map
-        // of constants to node IDs.
-        auto it = constants_.find(constant);
-        if (it == constants_.end()) {
-          constants_.insert({constant, {}});
-          it = constants_.find(constant);
-        }
-        // Record the mapping from constant value to current node and position.
-        // We defer creating the immediate nodes until we have traversed all
-        // instructions.
-        it->second.push_back({currentNodeNumber, position});
+        // of constants to node IDs and positions. We defer creating the
+        // immediate nodes until we have traversed all
+        constants_[constant].push_back({currentNodeNumber, position});
       } else if (const auto* operand =
                      llvm::dyn_cast<llvm::Instruction>(value)) {
 #ifdef PROGRAML_FUTURE_NODE_REPRESENTATION

--- a/deeplearning/ml4pl/graphs/llvm2graph/node_encoder_test.py
+++ b/deeplearning/ml4pl/graphs/llvm2graph/node_encoder_test.py
@@ -14,51 +14,99 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Unit tests for //deeplearning/ml4pl/graphs/llvm2graph:node_encoder."""
+import networkx as nx
+
 from deeplearning.ml4pl.graphs import programl
+from deeplearning.ml4pl.graphs import programl_pb2
 from deeplearning.ml4pl.graphs.llvm2graph import node_encoder
 from labm8.py import test
 
 
 FLAGS = test.FLAGS
 
+pytest_plugins = ["deeplearning.ml4pl.testing.fixtures.llvm_program_graph"]
 
-def test_EncodeNodes_equivalent_preprocessed_text():
+
+@test.Fixture(scope="session")
+def encoder() -> node_encoder.GraphNodeEncoder:
+  """A session-level fixture to re-use a graph encoder instance."""
+  return node_encoder.GraphNodeEncoder()
+
+
+def test_EncodeNodes_equivalent_preprocessed_text(
+  encoder: node_encoder.GraphNodeEncoder,
+):
   """Test equivalence of nodes that pre-process to the same text."""
   builder = programl.GraphBuilder()
   a = builder.AddNode(text="%7 = add nsw i32 %5, -1")
   b = builder.AddNode(text="%9 = add nsw i32 %5, -2")
   g = builder.g
 
-  encoder = node_encoder.GraphNodeEncoder()
   encoder.EncodeNodes(g)
 
   assert g.nodes[a]["preprocessed_text"] == "<%ID> = add nsw i32 <%ID>, <INT>"
   assert g.nodes[b]["preprocessed_text"] == "<%ID> = add nsw i32 <%ID>, <INT>"
 
 
-def test_EncodeNodes_encoded_values():
+def test_EncodeNodes_identifier(encoder: node_encoder.GraphNodeEncoder):
+  """Test the encoding of identifier nodes."""
+  builder = programl.GraphBuilder()
+  a = builder.AddNode(text="abcd", type=programl_pb2.Node.IDENTIFIER)
+  g = builder.g
+
+  encoder.EncodeNodes(g)
+  assert g.nodes[a]["text"] == "abcd"
+  assert g.nodes[a]["preprocessed_text"] == "!IDENTIFIER"
+
+
+def test_EncodeNodes_immediate(encoder: node_encoder.GraphNodeEncoder):
+  """Test the encoding of immediate nodes."""
+  builder = programl.GraphBuilder()
+  a = builder.AddNode(text="abcd", type=programl_pb2.Node.IMMEDIATE)
+  g = builder.g
+
+  encoder.EncodeNodes(g)
+  assert g.nodes[a]["text"] == "abcd"
+  assert g.nodes[a]["preprocessed_text"] == "!IMMEDIATE"
+
+
+def test_EncodeNodes_encoded_values(encoder: node_encoder.GraphNodeEncoder):
   """Test that "x" attribute of a node matches dictionary value."""
   builder = programl.GraphBuilder()
   a = builder.AddNode(text="br label %4")
   g = builder.g
 
-  encoder = node_encoder.GraphNodeEncoder()
   encoder.EncodeNodes(g)
 
   assert g.nodes[a]["x"][0] == encoder.dictionary["br label <%ID>"]
 
 
-def test_EncodeNodes_encoded_values_differ_between_statements():
+def test_EncodeNodes_encoded_values_differ_between_statements(
+  encoder: node_encoder.GraphNodeEncoder,
+):
   """Test that "x" attribute of nodes differ between different texts."""
   builder = programl.GraphBuilder()
   a = builder.AddNode(text="%7 = add nsw i32 %5, -1")
   b = builder.AddNode(text="br label %4")
   g = builder.g
 
-  encoder = node_encoder.GraphNodeEncoder()
   encoder.EncodeNodes(g)
 
   assert g.nodes[a]["x"][0] != g.nodes[b]["x"][0]
+
+
+def test_EncodeNodes_llvm_program_graph(llvm_program_graph_nx: nx.MultiDiGraph):
+  """Black-box test encoding LLVM program graphs."""
+  encoder = node_encoder.GraphNodeEncoder()
+  g = llvm_program_graph_nx.copy()
+  encoder.EncodeNodes(g)
+
+  # This assumes that all of the test graphs have at least one statement.
+  num_statements = sum(
+    1 if data["type"] == programl_pb2.Node.STATEMENT else 0
+    for _, data in g.nodes(data=True)
+  )
+  assert num_statements >= 1
 
 
 if __name__ == "__main__":

--- a/deeplearning/ml4pl/graphs/programl.py
+++ b/deeplearning/ml4pl/graphs/programl.py
@@ -29,6 +29,7 @@ Example usage:
         < /tmp/proto.pb > /tmp/proto.pbtxt
 """
 import enum
+import pickle
 import sys
 from typing import List
 from typing import Optional
@@ -51,6 +52,8 @@ class InputOutputFormat(enum.Enum):
   PB = 1
   # A text protocol buffer.
   PBTXT = 2
+  # A pickled networkx graph.
+  NX = 3
 
 
 app.DEFINE_enum(
@@ -329,6 +332,8 @@ def FromBytes(
     proto.ParseFromString(data)
   elif fmt == InputOutputFormat.PBTXT:
     pbutil.FromString(data.decode("utf-8"), proto)
+  elif fmt == InputOutputFormat.NX:
+    NetworkXToProgramGraph(pickle.loads(data), proto=proto)
   else:
     raise ValueError(f"Unknown program graph format: {fmt}")
 
@@ -357,6 +362,8 @@ def ToBytes(
     return program_graph.SerializeToString()
   elif fmt == InputOutputFormat.PBTXT:
     return str(program_graph).encode("utf-8")
+  elif fmt == InputOutputFormat.NX:
+    return pickle.dumps(ProgramGraphToNetworkX(program_graph))
   else:
     raise ValueError(f"Unknown program graph format: {fmt}")
 

--- a/deeplearning/ml4pl/graphs/programl_format_conversion_tests.py
+++ b/deeplearning/ml4pl/graphs/programl_format_conversion_tests.py
@@ -1,0 +1,69 @@
+# Copyright 2019-2020 the ProGraML authors.
+#
+# Contact Chris Cummins <chrisc.101@gmail.com>.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for //deeplearning/ml4pl/graphs:programl binary.
+
+This file tests conversion different combinations of input and output graph
+formats using the command line tool.
+"""
+import pickle
+import subprocess
+
+import networkx as nx
+
+from deeplearning.ml4pl.graphs import programl_pb2
+from labm8.py import bazelutil
+from labm8.py import test
+
+pytest_plugins = ["deeplearning.ml4pl.testing.fixtures.llvm_program_graph"]
+
+BINARY = bazelutil.DataPath("phd/deeplearning/ml4pl/graphs/programl")
+
+FLAGS = test.FLAGS
+
+
+@test.Parametrize("stdout_fmt", ("pb", "pbtxt", "nx"))
+def test_pb_conversion(
+  llvm_program_graph: programl_pb2.ProgramGraph, stdout_fmt: str
+):
+  """Test format conversion from text protocol buffer."""
+  assert subprocess.check_output(
+    [str(BINARY), "--stdin_fmt=pb", f"--stdout_fmt={stdout_fmt}"],
+    input=llvm_program_graph.SerializeToString(),
+  )
+
+
+@test.Parametrize("stdout_fmt", ("pb", "pbtxt", "nx"))
+def test_pbtxt_conversion(
+  llvm_program_graph: programl_pb2.ProgramGraph, stdout_fmt: str
+):
+  """Test format conversion from text protocol buffer."""
+  assert subprocess.check_output(
+    [str(BINARY), "--stdin_fmt=pbtxt", f"--stdout_fmt={stdout_fmt}"],
+    input=str(llvm_program_graph).encode("utf-8"),
+  )
+
+
+@test.Parametrize("stdout_fmt", ("pb", "pbtxt", "nx"))
+def test_nx_conversion(llvm_program_graph_nx: nx.MultiDiGraph, stdout_fmt: str):
+  """Test format conversion from networkx graph."""
+  assert subprocess.check_output(
+    [str(BINARY), "--stdin_fmt=nx", f"--stdout_fmt={stdout_fmt}"],
+    input=pickle.dumps(llvm_program_graph_nx),
+  )
+
+
+if __name__ == "__main__":
+  test.Main()


### PR DESCRIPTION
This updates the new llvm2graph implementation to be backward compatible with the old graph constructor.

Additionally, this makes the `node_encoder` executable as a binary, where it reads a proto from stdin, encodes it, and writes the result to stdout. You can now do full LLVM IR -> Graph -> Encoded Graph by chaining the two binaries, e.g.:

```sh
$ bazel build -c opt //deeplearning/ml4pl/graphs/llvm2graph:llvm2graph_ld_preload \
     //deeplearning/ml4pl/graphs/llvm2graph:node_encoder
$ bazel-bin/deeplearning/ml4pl/graphs/llvm2graph/llvm2graph_ld_preload \
    deeplearning/ml4pl/testing/data/bytecode_regression_tests/560.ll \
    | bazel-bin/deeplearning/ml4pl/graphs/llvm2graph/node_encoder
```

This also adds support for reading and writing networkx graphs from stdin and stdout using the `--stdin_fmt=nx` and `--stdout_fmt=nx` flags, respectively.

Changes that bring llvm2graph behavior in-line with the legacy implementation:

1. `text` field of statement nodes now contain the full instruction text, e.g. `%3 = add %1 %2`.
1. `text` field of immediate or identifier nodes is set to `!IMMEDIATE` and `!IDENTIFIER`, respectively.
1. The node encoder sets the `x` attributes of immediate and identifier nodes to their corresponding node embedding indices.

Behavior that remains inconsistent with the legacy llvm2graph constructor:

1. Immediate nodes are correctly typed as such, rather than being set as identifiers.
1. Non-exiting functions are not rejected by the graph constructor.