### PR TITLE
Fix alignment of pre-processed node texts.

### DIFF
--- a/deeplearning/ml4pl/graphs/graphviz_converter.h
+++ b/deeplearning/ml4pl/graphs/graphviz_converter.h
@@ -19,11 +19,12 @@
 
 #include "boost/graph/graphviz.hpp"
 #include "deeplearning/ml4pl/graphs/programl.pb.h"
+#include "labm8/cpp/string.h"
 
 namespace ml4pl {
 
 // Serialize the given program graph to an output stream.
-void SerializeGraphVizToString(const ProgramGraph& graph,
-                               std::ostream* ostream);
+void SerializeGraphVizToString(const ProgramGraph& graph, std::ostream* ostream,
+                               const string& nodeLabels = "text");
 
 }  // namespace ml4pl

--- a/deeplearning/ml4pl/graphs/graphviz_converter_py.cc
+++ b/deeplearning/ml4pl/graphs/graphviz_converter_py.cc
@@ -24,14 +24,15 @@
 #include <pybind11/pybind11.h>
 
 // Convert the given serialized program graph proto to a graphviz string.
-string ProgramGraphToGraphviz(const string& serializedProto) {
+string ProgramGraphToGraphviz(const string& serializedProto,
+                              const string& nodeLabels) {
   // Parse the input protocol buffer.
   ml4pl::ProgramGraph graph;
   graph.ParseFromString(serializedProto);
 
   // Serialize to graphviz.
   std::stringstream buffer;
-  ml4pl::SerializeGraphVizToString(graph, &buffer);
+  ml4pl::SerializeGraphVizToString(graph, &buffer, nodeLabels);
   return buffer.str();
 }
 

--- a/deeplearning/ml4pl/graphs/labelled/dataflow/annotate.py
+++ b/deeplearning/ml4pl/graphs/labelled/dataflow/annotate.py
@@ -178,7 +178,7 @@ def _AnnotateInSubprocess(
   if binary_graph:
     stdin = graph
   else:
-    stdin = programl.ToBytes(graph, fmt=programl.InputOutputFormat.PB)
+    stdin = programl.ToBytes(graph, fmt=programl.StdoutGraphFormat.PB)
 
   # Run this analysis script.
   stdout, stderr = process.communicate(stdin)
@@ -200,7 +200,7 @@ def _AnnotateInSubprocess(
   # Construct the protocol buffer from stdout.
   output = programl.FromBytes(
     stdout,
-    programl.InputOutputFormat.PB,
+    programl.StdinGraphFormat.PB,
     proto=programl_pb2.ProgramGraphs(),
     empty_okay=True,
   )

--- a/deeplearning/ml4pl/graphs/labelled/dataflow/annotate_test.py
+++ b/deeplearning/ml4pl/graphs/labelled/dataflow/annotate_test.py
@@ -43,20 +43,20 @@ def one_proto() -> programl_pb2.ProgramGraph:
   return next(random_programl_generator.EnumerateTestSet())
 
 
-@test.Fixture(scope="session", params=list(programl.InputOutputFormat))
-def stdin_fmt(request) -> programl.InputOutputFormat:
+@test.Fixture(scope="session", params=list(programl.StdinGraphFormat))
+def stdin_fmt(request) -> programl.StdinGraphFormat:
   """A test fixture which enumerates stdin formats."""
   return request.param
 
 
-@test.Fixture(scope="session", params=list(programl.InputOutputFormat))
-def stdout_fmt(request) -> programl.InputOutputFormat:
+@test.Fixture(scope="session", params=list(programl.StdoutGraphFormat))
+def stdout_fmt(request) -> programl.StdoutGraphFormat:
   """A test fixture which enumerates stdout formats."""
   return request.param
 
 
 @test.Fixture(scope="session", params=list(annotate.AVAILABLE_ANALYSES))
-def analysis(request) -> programl.InputOutputFormat:
+def analysis(request) -> str:
   """A test fixture which yields all analysis names."""
   return request.param
 

--- a/deeplearning/ml4pl/graphs/labelled/dataflow/make_data_flow_analysis_dataset.py
+++ b/deeplearning/ml4pl/graphs/labelled/dataflow/make_data_flow_analysis_dataset.py
@@ -233,7 +233,7 @@ def ProcessWorker(packed_args) -> AnnotationResult:
         annotated_graphs = annotate.Annotate(
           analysis,
           programl.FromBytes(
-            program_graph.serialized_proto, programl.InputOutputFormat.PB
+            program_graph.serialized_proto, programl.StdinGraphFormat.PB
           ),
           n=FLAGS.n,
           timeout=FLAGS.annotator_timeout,

--- a/deeplearning/ml4pl/graphs/llvm2graph/llvm_graph_builder.cc
+++ b/deeplearning/ml4pl/graphs/llvm2graph/llvm_graph_builder.cc
@@ -242,7 +242,12 @@ labm8::StatusOr<FunctionEntryExits> LlvmGraphBuilder::VisitFunction(
   // Construct the identifier data elements for arguments and connect data
   // edges.
   for (auto it : argumentConsumers) {
-    auto argument = AddIdentifier(PrintToString(*it.first), functionNumber);
+#ifdef PROGRAML_FUTURE_NODE_REPRESENTATION
+    auto text = PrintToString(*it.first);
+#else
+    auto text = "!IDENTIFIER";
+#endif
+    auto argument = AddIdentifier(text, functionNumber);
     for (auto argumentConsumer : it.second) {
       AddDataEdge(argument.first, argumentConsumer.first,
                   argumentConsumer.second);

--- a/deeplearning/ml4pl/graphs/llvm2graph/llvm_graph_builder.cc
+++ b/deeplearning/ml4pl/graphs/llvm2graph/llvm_graph_builder.cc
@@ -168,15 +168,8 @@ labm8::StatusOr<BasicBlockEntryExit> LlvmGraphBuilder::VisitBasicBlock(
         // Defer creation of the edge from producer -> data.
         dataEdgesToAdd->push_back({operand, identifier.first});
       } else if (const auto* operand = llvm::dyn_cast<llvm::Argument>(value)) {
-        // Look up the list of argument consumers, or create one.
-        auto it = argumentConsumers->find(operand);
-        if (it == argumentConsumers->end()) {
-          argumentConsumers->insert({operand, {}});
-          it = argumentConsumers->find(operand);
-        }
-
         // Record the usage of the argument.
-        it->second.push_back({currentNodeNumber, position});
+        (*argumentConsumers)[operand].push_back({currentNodeNumber, position});
       } else if (!(
                      // Basic blocks are not considered data. There will instead
                      // be a control edge from this instruction to the entry

--- a/deeplearning/ml4pl/graphs/llvm2graph/node_encoder.py
+++ b/deeplearning/ml4pl/graphs/llvm2graph/node_encoder.py
@@ -88,7 +88,14 @@ class GraphNodeEncoder(object):
       inst2vec_preprocess.PreprocessStatement(x[0] if len(x) else "")
       for x in preprocessed_lines
     ]
-    for (node, data), text in zip(g.nodes(data=True), preprocessed_texts):
+    for (_, data), text in zip(
+      (
+        (_, data)
+        for _, data in g.nodes(data=True)
+        if data["type"] == programl_pb2.Node.STATEMENT
+      ),
+      preprocessed_texts,
+    ):
       data["preprocessed_text"] = text
       data["x"] = [self.dictionary.get(text, self.dictionary["!UNK"])]
 

--- a/deeplearning/ml4pl/graphs/llvm2graph/node_encoder_test.py
+++ b/deeplearning/ml4pl/graphs/llvm2graph/node_encoder_test.py
@@ -108,6 +108,12 @@ def test_EncodeNodes_llvm_program_graph(llvm_program_graph_nx: nx.MultiDiGraph):
   )
   assert num_statements >= 1
 
+  # Check for the presence of expected node attributes.
+  for _, data in g.nodes(data=True):
+    assert len(data["x"]) == 1
+    assert len(data["y"]) == 0
+    assert "preprocessed_text" in data
+
 
 if __name__ == "__main__":
   test.Main()

--- a/deeplearning/ml4pl/graphs/programl.py
+++ b/deeplearning/ml4pl/graphs/programl.py
@@ -65,6 +65,9 @@ class StdoutGraphFormat(enum.Enum):
   PBTXT = 2
   # A pickled networkx graph.
   NX = 3
+  # A graphviz dot string. WARNING: Conversion to DOT format is lossy. A DOT
+  # format graph cannot be converted back to a protocol buffer.
+  DOT = 4
 
 
 app.DEFINE_enum(
@@ -383,6 +386,8 @@ def ToBytes(
     return str(program_graph).encode("utf-8")
   elif fmt == StdoutGraphFormat.NX:
     return pickle.dumps(ProgramGraphToNetworkX(program_graph))
+  elif fmt == StdoutGraphFormat.DOT:
+    return ProgramGraphToGraphviz(program_graph).encode("utf-8")
   else:
     raise ValueError(f"Unknown program graph format: {fmt}")
 

--- a/deeplearning/ml4pl/graphs/programl.py
+++ b/deeplearning/ml4pl/graphs/programl.py
@@ -79,6 +79,11 @@ app.DEFINE_enum(
   StdoutGraphFormat.PBTXT,
   "The format for output program graphs.",
 )
+app.DEFINE_string(
+  "node_labels",
+  "text",
+  "The Node message field to use for graphviz node labels.",
+)
 
 
 class GraphBuilder(object):
@@ -306,7 +311,9 @@ def NetworkXToProgramGraph(
   return proto
 
 
-def ProgramGraphToGraphviz(proto: programl_pb2) -> str:
+def ProgramGraphToGraphviz(
+  proto: programl_pb2, node_labels: Optional[str] = None
+) -> str:
   """Convert a program graph protocol buffer to a graphviz dot string.
 
   Wraps the C++ method defined the graphviz_convert_py.cc pybind module.
@@ -318,7 +325,8 @@ def ProgramGraphToGraphviz(proto: programl_pb2) -> str:
     A string suitable for feeding into `dot`.
   """
   proto_str = proto.SerializeToString()
-  return graphviz_converter_py.ProgramGraphToGraphviz(proto_str)
+  node_labels = node_labels or FLAGS.node_labels
+  return graphviz_converter_py.ProgramGraphToGraphviz(proto_str, node_labels)
 
 
 def FromBytes(

--- a/deeplearning/ml4pl/graphs/programl.py
+++ b/deeplearning/ml4pl/graphs/programl.py
@@ -45,8 +45,19 @@ from labm8.py import pbutil
 FLAGS = app.FLAGS
 
 
-class InputOutputFormat(enum.Enum):
-  """The input/output format for converting protocol buffer to byte strings."""
+class StdinGraphFormat(enum.Enum):
+  """The format of a graph read from stdin."""
+
+  # A binary protocol buffer.
+  PB = 1
+  # A text protocol buffer.
+  PBTXT = 2
+  # A pickled networkx graph.
+  NX = 3
+
+
+class StdoutGraphFormat(enum.Enum):
+  """The format of a graph written to stdout."""
 
   # A binary protocol buffer.
   PB = 1
@@ -58,14 +69,14 @@ class InputOutputFormat(enum.Enum):
 
 app.DEFINE_enum(
   "stdin_fmt",
-  InputOutputFormat,
-  InputOutputFormat.PBTXT,
+  StdinGraphFormat,
+  StdinGraphFormat.PBTXT,
   "The format for input program graph.",
 )
 app.DEFINE_enum(
   "stdout_fmt",
-  InputOutputFormat,
-  InputOutputFormat.PBTXT,
+  StdoutGraphFormat,
+  StdoutGraphFormat.PBTXT,
   "The format for output program graphs.",
 )
 
@@ -312,7 +323,7 @@ def ProgramGraphToGraphviz(proto: programl_pb2) -> str:
 
 def FromBytes(
   data: bytes,
-  fmt: InputOutputFormat,
+  fmt: StdinGraphFormat,
   proto: Optional[programl_pb2.ProgramGraph] = None,
   empty_okay: bool = False,
 ) -> programl_pb2.ProgramGraph:
@@ -328,11 +339,11 @@ def FromBytes(
     A program graph protocol buffer.
   """
   proto = proto or programl_pb2.ProgramGraph()
-  if fmt == InputOutputFormat.PB:
+  if fmt == StdinGraphFormat.PB:
     proto.ParseFromString(data)
-  elif fmt == InputOutputFormat.PBTXT:
+  elif fmt == StdinGraphFormat.PBTXT:
     pbutil.FromString(data.decode("utf-8"), proto)
-  elif fmt == InputOutputFormat.NX:
+  elif fmt == StdinGraphFormat.NX:
     NetworkXToProgramGraph(pickle.loads(data), proto=proto)
   else:
     raise ValueError(f"Unknown program graph format: {fmt}")
@@ -347,7 +358,7 @@ def FromBytes(
 
 
 def ToBytes(
-  program_graph: programl_pb2.ProgramGraph, fmt: InputOutputFormat
+  program_graph: programl_pb2.ProgramGraph, fmt: StdoutGraphFormat
 ) -> bytes:
   """Convert a program graph to a byte array.
 
@@ -358,11 +369,11 @@ def ToBytes(
   Returns:
     A byte array.
   """
-  if fmt == InputOutputFormat.PB:
+  if fmt == StdoutGraphFormat.PB:
     return program_graph.SerializeToString()
-  elif fmt == InputOutputFormat.PBTXT:
+  elif fmt == StdoutGraphFormat.PBTXT:
     return str(program_graph).encode("utf-8")
-  elif fmt == InputOutputFormat.NX:
+  elif fmt == StdoutGraphFormat.NX:
     return pickle.dumps(ProgramGraphToNetworkX(program_graph))
   else:
     raise ValueError(f"Unknown program graph format: {fmt}")

--- a/deeplearning/ml4pl/graphs/programl_benchmark_test.py
+++ b/deeplearning/ml4pl/graphs/programl_benchmark_test.py
@@ -60,12 +60,6 @@ def node_count(request) -> int:
   return request.param
 
 
-@test.Fixture(scope="session", params=list(programl.InputOutputFormat))
-def fmt(request) -> programl.InputOutputFormat:
-  """A test fixture which enumerates protocol buffer formats."""
-  return request.param
-
-
 ###############################################################################
 # Benchmarks.
 ###############################################################################

--- a/deeplearning/ml4pl/graphs/programl_test.py
+++ b/deeplearning/ml4pl/graphs/programl_test.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 """Unit tests for //deeplearning/ml4pl/graphs:programl."""
 import random
+from typing import Tuple
 
 from deeplearning.ml4pl.graphs import programl
 from deeplearning.ml4pl.graphs import programl_pb2
@@ -58,12 +59,6 @@ def graph_y_dimensionality(request) -> int:
 @test.Fixture(scope="session", params=(None, 10, 100))
 def node_count(request) -> int:
   """A test fixture which enumerates node_counts."""
-  return request.param
-
-
-@test.Fixture(scope="session", params=list(programl.InputOutputFormat))
-def fmt(request) -> programl.InputOutputFormat:
-  """A test fixture which enumerates protocol buffer formats."""
   return request.param
 
 
@@ -133,14 +128,6 @@ def test_fuzz_GraphBuilder():
     builder.AddEdge(random.choice(nodes), random.choice(nodes))
   assert builder.g
   assert builder.proto
-
-
-@decorators.loop_for(seconds=3)
-def test_fuzz_proto_bytes_equivalence(fmt: programl.InputOutputFormat):
-  """Test that conversion to and from bytes does not change the proto."""
-  input = random_programl_generator.CreateRandomProto()
-  output = programl.FromBytes(programl.ToBytes(input, fmt), fmt)
-  assert input == output
 
 
 @decorators.loop_for(seconds=3)

--- a/labm8/cpp/statusor.h
+++ b/labm8/cpp/statusor.h
@@ -82,6 +82,7 @@
 #pragma once
 
 #include <new>
+#include <stdexcept>
 #include <string>
 #include <utility>
 
@@ -153,6 +154,18 @@ class StatusOr {
   Status status_;
   T value_;
 };
+
+////////////////////////////////////////////////////////////////////////////////
+// labm8 extension code
+
+// Throw an error if StatusOr is not Status::OK.
+template <typename T, typename Error = std::runtime_error>
+T StatusOrToException(StatusOr<T> statusOr) {
+  if (statusOr.ok()) {
+    return statusOr.ValueOrDie();
+  }
+  throw Error(statusOr.status().ToString());
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 // Implementation details for StatusOr<T>


### PR DESCRIPTION
The iterator to set the pre-processed node texts in github.com/ChrisCummins/phd/pull/95 was wrong, causing nodes to have the incorrect pre-processed text set. This patch set:

1. Corrects the values set for `Node.pre_processed` and `Node.x`.
1. Changes the text of argument data flow nodes to `!IDENTIFIER` (this doesn't affect the node encoding, it's just to match the text of non-argument identifiers).
1. Adds a `--stdout_fmt=dot` output format to directly generate Graphviz graphs from CLI tools.
1. Adds a `--node_labels=text` flag to set the node labels for Graphviz graphs. E.g. use `--node_labels=preprocessed_text` to generate a graph with the pre-processed text as node labels, or `--node_labels=x` to use the embedding indices.

An example of generating a Graphviz graph from an encoded graph using the embedding indices as node labels:

```sh
$ bazel run -c opt //deeplearning/ml4pl/graphs/llvm2graph -- \
    $PWD/deeplearning/ml4pl/testing/data/bytecode_regression_tests/560.ll \
    | bazel run -c opt //deeplearning/ml4pl/graphs/llvm2graph:node_encoder -- \
    --stdout_fmt=dot --node_labels=x
```