### PR TITLE
ml4pl: Add a utility to export unlabelled graph db

### DIFF
--- a/deeplearning/ml4pl/cmd/BUILD
+++ b/deeplearning/ml4pl/cmd/BUILD
@@ -1,0 +1,28 @@
+# Command line programs for ml4pl.
+#
+# Copyright 2019-2020 the ProGraML authors.
+#
+# Contact Chris Cummins <chrisc.101@gmail.com>.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+py_binary(
+    name = "dump_unlabelled_graph_db",
+    srcs = ["dump_unlabelled_graph_db.py"],
+    deps = [
+        "//deeplearning/ml4pl/graphs:programl",
+        "//deeplearning/ml4pl/graphs/unlabelled:unlabelled_graph_database_exporter",
+        "//labm8/py:app",
+        "//labm8/py:progress",
+    ],
+)

--- a/deeplearning/ml4pl/cmd/dump_unlabelled_graph_db.py
+++ b/deeplearning/ml4pl/cmd/dump_unlabelled_graph_db.py
@@ -1,0 +1,71 @@
+# Copyright 2019-2020 the ProGraML authors.
+#
+# Contact Chris Cummins <chrisc.101@gmail.com>.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Dump the contents of an unlabelled graph database as files.
+
+Write each unique graph to a file, named for its checksum. Supports dumping to
+all graph representation formats: protocol buffers, networkx graphs, Graphviz
+dotfiles, etc.
+
+For example, to dump the contents of a local sqlite database as networkx graphs:
+
+  $ bazel run //deeplearning/ml4pl/cmd:dump_unlabelled_graph_db -- \
+      --proto_db=sqlite:////path/to/db \
+      --outdir=/path/to/outdir \
+      --fmt=nx
+
+Partial exports are supported - exporting will resume where it left off.
+"""
+from deeplearning.ml4pl.graphs import programl
+from deeplearning.ml4pl.graphs.unlabelled import (
+  unlabelled_graph_database_exporter,
+)
+from labm8.py import app
+from labm8.py import progress
+
+app.DEFINE_output_path(
+  "outdir",
+  "/tmp/phd/ml4pl/graphs",
+  "The directory to write output files to.",
+  is_dir=True,
+)
+app.DEFINE_enum(
+  "fmt",
+  programl.StdoutGraphFormat,
+  programl.StdoutGraphFormat.PB,
+  "The file type for graphs to dump.",
+)
+app.DEFINE_integer(
+  "batch_size",
+  1024,
+  "Tuning parameter. The number of graphs to read in a batch.",
+)
+FLAGS = app.FLAGS
+
+
+def Main():
+  """Main entry point."""
+  exporter = unlabelled_graph_database_exporter.GraphDatabaseExporter(
+    db=FLAGS.proto_db(),
+    outdir=FLAGS.outdir,
+    fmt=FLAGS.fmt(),
+    batch_size=FLAGS.batch_size,
+  )
+
+  progress.Run(exporter)
+
+
+if __name__ == "__main__":
+  app.Run(Main)

--- a/deeplearning/ml4pl/graphs/BUILD
+++ b/deeplearning/ml4pl/graphs/BUILD
@@ -132,11 +132,7 @@ py_binary(
     name = "programl",
     srcs = ["programl.py"],
     data = [":graphviz_converter_py.so"],
-    visibility = [
-        "//deeplearning/ml4pl/graphs:__subpackages__",
-        "//deeplearning/ml4pl/seq:__subpackages__",
-        "//deeplearning/ml4pl/testing:__subpackages__",
-    ],
+    visibility = ["//visibility:public"],
     deps = [
         ":programl_pb_py",
         "//labm8/py:app",

--- a/deeplearning/ml4pl/graphs/programl.py
+++ b/deeplearning/ml4pl/graphs/programl.py
@@ -456,6 +456,32 @@ def FromBytes(
   return proto
 
 
+def StdoutGraphFormatToFileExtension(fmt: StdoutGraphFormat):
+  if fmt == StdoutGraphFormat.PB:
+    return ".pb"
+  elif fmt == StdoutGraphFormat.PBTXT:
+    return ".pbtxt"
+  elif fmt == StdoutGraphFormat.NX:
+    return ".nx.pickle"
+  elif fmt == StdoutGraphFormat.DOT:
+    return ".dot"
+  else:
+    raise TypeError(f"Unknown fmt: {fmt}")
+
+
+def StdoutGraphFormatToStdinGraphFormat(fmt: StdoutGraphFormat):
+  if fmt == StdoutGraphFormat.PB:
+    return StdinGraphFormat.PB
+  elif fmt == StdoutGraphFormat.PBTXT:
+    return StdinGraphFormat.PBTXT
+  elif fmt == StdoutGraphFormat.NX:
+    return StdinGraphFormat.NX
+  elif fmt == StdoutGraphFormat.DOT:
+    raise TypeError("Cannot construct graphs from dot format")
+  else:
+    raise TypeError(f"Unknown fmt: {fmt}")
+
+
 def ToBytes(
   program_graph: programl_pb2.ProgramGraph, fmt: StdoutGraphFormat
 ) -> bytes:
@@ -478,6 +504,25 @@ def ToBytes(
     return ProgramGraphToGraphviz(program_graph).encode("utf-8")
   else:
     raise ValueError(f"Unknown program graph format: {fmt}")
+
+
+def SerializedProgramGraphToBytes(
+  serialized_proto: bytes, fmt: StdoutGraphFormat
+) -> bytes:
+  """Convert a serialized ProgramGraphProto to a byte array.
+
+  Args:
+    serialized_proto: The serialized program graph proto.
+    fmt: The output format of the byte array.
+
+  Returns:
+    An array of bytes.
+  """
+  if fmt == StdoutGraphFormat.PB:
+    return serialized_proto
+  proto = programl_pb2.ProgramGraph()
+  proto.ParseFromString(serialized_proto)
+  return ToBytes(proto, fmt)
 
 
 def ReadStdin() -> programl_pb2.ProgramGraph:

--- a/deeplearning/ml4pl/graphs/programl_test.py
+++ b/deeplearning/ml4pl/graphs/programl_test.py
@@ -110,6 +110,32 @@ def test_proto_networkx_equivalence_with_preallocated_proto(
   assert len(llvm_program_graph.edge) == len(proto_out.edge)
 
 
+@test.Parametrize("fmt", list(programl.StdoutGraphFormat))
+def test_StdoutGraphFormatToFileExtension_smoke_test(
+  fmt: programl.StdoutGraphFormat,
+):
+  assert programl.StdoutGraphFormatToFileExtension(fmt)
+
+
+def test_StdoutGraphFormatToFileExtension():
+  assert (
+    programl.StdoutGraphFormatToFileExtension(programl.StdoutGraphFormat.PB)
+    == ".pb"
+  )
+  assert (
+    programl.StdoutGraphFormatToFileExtension(programl.StdoutGraphFormat.PBTXT)
+    == ".pbtxt"
+  )
+  assert (
+    programl.StdoutGraphFormatToFileExtension(programl.StdoutGraphFormat.NX)
+    == ".nx.pickle"
+  )
+  assert (
+    programl.StdoutGraphFormatToFileExtension(programl.StdoutGraphFormat.DOT)
+    == ".dot"
+  )
+
+
 ###############################################################################
 # Fuzzers.
 ###############################################################################

--- a/deeplearning/ml4pl/graphs/unlabelled/BUILD
+++ b/deeplearning/ml4pl/graphs/unlabelled/BUILD
@@ -91,3 +91,34 @@ py_test(
         "//third_party/py/sqlalchemy",
     ],
 )
+
+py_library(
+    name = "unlabelled_graph_database_exporter",
+    srcs = ["unlabelled_graph_database_exporter.py"],
+    visibility = ["//deeplearning/ml4pl:__subpackages__"],
+    deps = [
+        ":unlabelled_graph_database",
+        "//deeplearning/ml4pl/graphs:programl",
+        "//labm8/py:app",
+        "//labm8/py:fs",
+        "//labm8/py:labtypes",
+        "//labm8/py:ppar",
+        "//labm8/py:progress",
+        "//third_party/py/sqlalchemy",
+    ],
+)
+
+py_test(
+    name = "unlabelled_graph_database_exporter_test",
+    srcs = ["unlabelled_graph_database_exporter_test.py"],
+    deps = [
+        ":unlabelled_graph_database",
+        ":unlabelled_graph_database_exporter",
+        "//deeplearning/ml4pl/graphs:programl",
+        "//deeplearning/ml4pl/testing:random_unlabelled_graph_database_generator",
+        "//deeplearning/ml4pl/testing:testing_databases",
+        "//labm8/py:app",
+        "//labm8/py:progress",
+        "//labm8/py:test",
+    ],
+)

--- a/deeplearning/ml4pl/graphs/unlabelled/unlabelled_graph_database_exporter.py
+++ b/deeplearning/ml4pl/graphs/unlabelled/unlabelled_graph_database_exporter.py
@@ -1,0 +1,145 @@
+# Copyright 2019-2020 the ProGraML authors.
+#
+# Contact Chris Cummins <chrisc.101@gmail.com>.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""This module defines a class for exporting unlabelled graph databases."""
+import pathlib
+
+import sqlalchemy as sql
+
+from deeplearning.ml4pl.graphs import programl
+from deeplearning.ml4pl.graphs.unlabelled import unlabelled_graph_database
+from labm8.py import app
+from labm8.py import fs
+from labm8.py import labtypes
+from labm8.py import ppar
+from labm8.py import progress
+
+FLAGS = app.FLAGS
+
+
+class GraphDatabaseExporter(progress.Progress):
+  """A class for exporting a database of unlabelled program graphs to files.
+
+  Serialized graph protocol buffers are read from the database in order of their
+  checksum string and converted to a different format if required. Partial
+  exports are supported by first checking the output directory to see if any
+  files have already been exported there, and if so, resuming the export from
+  that checksum.
+  """
+
+  def __init__(
+    self,
+    db: unlabelled_graph_database.Database,
+    outdir: pathlib.Path,
+    fmt: programl.StdoutGraphFormat,
+    batch_size: int = 512,
+  ):
+    """Constructor.
+
+    Args:
+      db: A database of unlabelled graphs.
+      outdir: The directory to write files to.
+      fmt: The file format to dump. One of
+      batch_size:
+    """
+    self.db = db
+    self.outdir = outdir
+    self.fmt = fmt
+    self.batch_size = batch_size
+
+    self.outdir.mkdir(exist_ok=True, parents=True)
+    self.file_suffix = programl.StdoutGraphFormatToFileExtension(self.fmt)
+
+    # Find the most recently exported file, if any.
+    exported_count = 0
+    self.most_recent_export = ""
+    for path in self.outdir.iterdir():
+      if path.name.endswith(self.file_suffix):
+        exported_count += 1
+        self.most_recent_export = max(path.name, self.most_recent_export)
+
+    # Compute the number of graphs that to be exported.
+    with self.db.Session() as session:
+      query = session.query(
+        sql.func.count(
+          sql.func.distinct(unlabelled_graph_database.ProgramGraphData.sha1)
+        )
+      )
+      if self.most_recent_export:
+        query = query.filter(
+          unlabelled_graph_database.ProgramGraphData.sha1
+          > self.most_recent_export
+        )
+      max_rows = query.scalar()
+
+    super(GraphDatabaseExporter, self).__init__(
+      name="export graphs", i=exported_count, n=max_rows
+    )
+
+  def Run(self):
+    """Run the exporter."""
+    with self.db.Session() as session:
+      # Get the IDs of the unique graphs.
+      ids_to_export = (
+        session.query(
+          sql.func.min(unlabelled_graph_database.ProgramGraphData.ir_id).label(
+            "ir_id"
+          ),
+        )
+        .group_by(unlabelled_graph_database.ProgramGraphData.sha1)
+        .order_by(unlabelled_graph_database.ProgramGraphData.sha1)
+      )
+
+      if self.most_recent_export:
+        ids_to_export = ids_to_export.filter(
+          unlabelled_graph_database.ProgramGraphData.sha1
+          > self.most_recent_export
+        )
+
+      ids_to_export = [r.ir_id for r in ids_to_export]
+
+    def ReadGraphs(ids_chunk):
+      """Read the checksum and serialized protos for a list of IR IDs."""
+      # We must create a disposable session to perform this query in since it
+      # will be executed in a background thread and SQLite requires session
+      # objects to be used only in the thread in which they are created.
+      with self.db.Session() as session:
+        batch = (
+          session.query(
+            unlabelled_graph_database.ProgramGraphData.sha1,
+            unlabelled_graph_database.ProgramGraphData.serialized_proto,
+          )
+          .filter(
+            unlabelled_graph_database.ProgramGraphData.ir_id.in_(ids_chunk)
+          )
+          .order_by(unlabelled_graph_database.ProgramGraphData.sha1)
+          .all()
+        )
+      return batch
+
+    # An iterator of queries to run. Each query reads a chunk of the ID list
+    # and returns the graphs.
+    queries = map(ReadGraphs, labtypes.Chunkify(ids_to_export, self.batch_size))
+
+    # Overlap the database reading and file writing in a background thread.
+    queries = ppar.ThreadedIterator(queries, max_queue_size=5)
+
+    for query in queries:
+      for sha1, serialized_proto in query:
+        self.ctx.i += 1
+        fs.Write(
+          self.outdir / f"{sha1}{self.file_suffix}",
+          programl.SerializedProgramGraphToBytes(serialized_proto, self.fmt),
+        )

--- a/deeplearning/ml4pl/graphs/unlabelled/unlabelled_graph_database_exporter_test.py
+++ b/deeplearning/ml4pl/graphs/unlabelled/unlabelled_graph_database_exporter_test.py
@@ -1,0 +1,110 @@
+# Copyright 2019-2020 the ProGraML authors.
+#
+# Contact Chris Cummins <chrisc.101@gmail.com>.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for //deeplearning/ml4pl/graphs/unlabelled:unlabelled_graph_database_exporter."""
+import pathlib
+
+from deeplearning.ml4pl.graphs import programl
+from deeplearning.ml4pl.graphs.unlabelled import unlabelled_graph_database
+from deeplearning.ml4pl.graphs.unlabelled import (
+  unlabelled_graph_database_exporter,
+)
+from deeplearning.ml4pl.testing import (
+  random_unlabelled_graph_database_generator,
+)
+from deeplearning.ml4pl.testing import testing_databases
+from labm8.py import app
+from labm8.py import progress
+from labm8.py import test
+
+
+FLAGS = app.FLAGS
+
+
+@test.Fixture(
+  scope="session",
+  params=testing_databases.GetDatabaseUrls(),
+  namer=testing_databases.DatabaseUrlNamer("graph_db"),
+)
+def immutable_empty_db(request) -> unlabelled_graph_database.Database:
+  """A test fixture which yields an empty graph proto database."""
+  yield from testing_databases.YieldDatabase(
+    unlabelled_graph_database.Database, request.param
+  )
+
+
+IMMUTABLE_TEST_DB_PROTO_COUNT = 100
+
+
+@test.Fixture(
+  scope="session",
+  params=testing_databases.GetDatabaseUrls(),
+  namer=testing_databases.DatabaseUrlNamer("graph_db"),
+)
+def immutable_test_db(request) -> unlabelled_graph_database.Database:
+  with testing_databases.DatabaseContext(
+    unlabelled_graph_database.Database, request.param
+  ) as db:
+    random_unlabelled_graph_database_generator.PopulateDatabaseWithRandomProgramGraphs(
+      db, IMMUTABLE_TEST_DB_PROTO_COUNT
+    )
+    yield db
+
+
+@test.Parametrize("fmt", list(programl.StdoutGraphFormat))
+def test_export_empty_db(
+  immutable_empty_db: unlabelled_graph_database.Database,
+  tempdir: pathlib.Path,
+  fmt: programl.StdoutGraphFormat,
+):
+  db = immutable_empty_db
+  outdir = tempdir / "graphs"
+  exporter = unlabelled_graph_database_exporter.GraphDatabaseExporter(
+    db=db, outdir=outdir, fmt=fmt,
+  )
+  progress.Run(exporter)
+  assert outdir.is_dir()
+  assert len(list(outdir.iterdir())) == 0
+
+
+@test.Parametrize("fmt", list(programl.StdoutGraphFormat))
+def test_export_test_db(
+  immutable_test_db: unlabelled_graph_database.Database,
+  tempdir: pathlib.Path,
+  fmt: programl.StdoutGraphFormat,
+):
+  db = immutable_test_db
+  outdir = tempdir / "graphs"
+  exporter = unlabelled_graph_database_exporter.GraphDatabaseExporter(
+    db=db, outdir=outdir, fmt=fmt,
+  )
+  progress.Run(exporter)
+  assert outdir.is_dir()
+  assert len(list(outdir.iterdir())) == IMMUTABLE_TEST_DB_PROTO_COUNT
+
+  # We can't convert from dot -> graph, so end the test here.
+  if fmt == programl.StdoutGraphFormat.DOT:
+    return
+
+  # Parse the dumped files.
+  for path in outdir.iterdir():
+    with open(path, "rb") as f:
+      programl.FromBytes(
+        f.read(), programl.StdoutGraphFormatToStdinGraphFormat(fmt)
+      )
+
+
+if __name__ == "__main__":
+  test.Main()

--- a/deeplearning/ml4pl/testing/random_unlabelled_graph_database_generator.py
+++ b/deeplearning/ml4pl/testing/random_unlabelled_graph_database_generator.py
@@ -106,9 +106,10 @@ def PopulateDatabaseWithRandomProgramGraphs(
   # Generate a full list of rows by randomly selecting from the graph pool.
   rows = [copy.deepcopy(random.choice(graph_pool)) for _ in range(proto_count)]
 
-  # Assign unique keys.
-  for i, row in enumerate(rows):
-    row.ir_id = i + 1
+  # Assign unique keys and checksums.
+  for i, row in enumerate(rows, start=1):
+    row.ir_id = i
+    row.data.sha1 = str(i) * 40
 
   with db.Session(commit=True) as session:
     session.add_all([copy.deepcopy(t) for t in rows])


### PR DESCRIPTION
This adds a command `//deeplearning/ml4pl/cmd:dump_unlabelled_graph_db` which can be used to export a graph database to a directory of files.

Each unique graph is written to a file, named for its checksum. Supports dumping to all graph representation formats: protocol buffers, networkx graphs, Graphviz dotfiles, etc.

For example, to dump the contents of a local sqlite database as networkx graphs:

```sh
$ bazel run //deeplearning/ml4pl/cmd:dump_graph_db -- \
    --proto_db=sqlite:////path/to/db \
    --outdir=/path/to/outdir \
    --fmt=nx
```

Partial exports are supported - exporting will resume where it left off.