### PR TITLE
ml4pl: Record LLVM profiling information

### DIFF
--- a/deeplearning/ml4pl/graphs/graph_builder.h
+++ b/deeplearning/ml4pl/graphs/graph_builder.h
@@ -56,6 +56,12 @@ class GraphBuilder {
 
   size_t NextNodeNumber() const { return graph_.node_size(); }
 
+  // Return a mutable pointer to the graph protocol buffer.
+  ProgramGraph* GetMutableProgramGraph() { return &graph_; }
+
+  // Return the graph protocol buffer.
+  const ProgramGraph& GetProgramGraph() const { return graph_; }
+
  private:
   ProgramGraph graph_;
 

--- a/deeplearning/ml4pl/graphs/llvm2graph/llvm_graph_builder.cc
+++ b/deeplearning/ml4pl/graphs/llvm2graph/llvm_graph_builder.cc
@@ -30,6 +30,7 @@
 #include "llvm/IR/Function.h"
 #include "llvm/IR/Instruction.h"
 #include "llvm/IR/Instructions.h"
+#include "llvm/IR/ProfileSummary.h"
 #include "llvm/Support/raw_ostream.h"
 
 namespace ml4pl {
@@ -94,6 +95,19 @@ labm8::StatusOr<BasicBlockEntryExit> LlvmGraphBuilder::VisitBasicBlock(
     previousNodeNumber = currentNodeNumber;
     currentNodeNumber = statement.first;
 
+    // Add profiling information, if available.
+    uint64_t profTotalWeight;
+    if (instruction.extractProfTotalWeight(profTotalWeight)) {
+      statement.second->set_llvm_profile_total_weight(profTotalWeight);
+    }
+    uint64_t profTrueWeight;
+    uint64_t profFalseWeight;
+    if (instruction.extractProfMetadata(profTrueWeight, profFalseWeight)) {
+      statement.second->set_llvm_profile_true_weight(profTrueWeight);
+      statement.second->set_llvm_profile_false_weight(profFalseWeight);
+    }
+
+    // Record the instruction in the function-level instructions map.
     instructions->insert({&instruction, currentNodeNumber});
 
     // A basic block consists of a linear sequence of instructions, so we can
@@ -326,6 +340,12 @@ labm8::StatusOr<ProgramGraph> LlvmGraphBuilder::Build(
     // Create the function message.
     auto fn = AddFunction(function.getName());
 
+    // Add profiling information, if available.
+    if (function.hasProfileData()) {
+      auto profileCount = function.getEntryCount();
+      fn.second->set_llvm_entry_count(profileCount.getValue());
+    }
+
     FunctionEntryExits functionEntryExits;
     ASSIGN_OR_RETURN(functionEntryExits, VisitFunction(function, fn.first));
 
@@ -358,6 +378,25 @@ labm8::StatusOr<ProgramGraph> LlvmGraphBuilder::Build(
     // Create data in-flow edges.
     for (auto destination : constant.second) {
       AddDataEdge(immmediate.first, destination.first, destination.second);
+    }
+
+    // Add profiling information, if available.
+    llvm::Metadata* profileMetadata = module.getModuleFlag("ProfileSummary");
+    if (profileMetadata) {
+      llvm::ProfileSummary* profileSummary =
+          llvm::ProfileSummary::getFromMD(profileMetadata);
+      CHECK(profileSummary) << "Module ProfileSummary is null";
+
+      LlvmProfile* profileMessage =
+          GetMutableProgramGraph()->mutable_llvm_profile();
+      profileMessage->set_num_functions(profileSummary->getNumFunctions());
+      profileMessage->set_max_function_count(
+          profileSummary->getMaxFunctionCount());
+      profileMessage->set_num_counts(profileSummary->getNumCounts());
+      profileMessage->set_total_count(profileSummary->getTotalCount());
+      profileMessage->set_max_count(profileSummary->getMaxCount());
+      profileMessage->set_max_internal_count(
+          profileSummary->getMaxInternalCount());
     }
   }
 

--- a/deeplearning/ml4pl/graphs/programl.proto
+++ b/deeplearning/ml4pl/graphs/programl.proto
@@ -43,11 +43,15 @@ message ProgramGraph {
   optional int32 data_flow_steps = 8;
   // The number of nodes with "positive" analysis results.
   optional int32 data_flow_positive_node_count = 9;
+  // Optional LLVM profiling information.
+  optional LlvmProfile llvm_profile = 100;
 }
 
 message Function {
   // The name of the function.
   required string name = 1;
+  // Optional LLVM profiling information.
+  optional uint64 llvm_entry_count = 100;
 }
 
 message Node {
@@ -70,6 +74,10 @@ message Node {
   // Optional vectors of node-level features and labels.
   repeated int64 x = 5;
   repeated int64 y = 6;
+  // Optional LLVM profiling information.
+  optional uint64 llvm_profile_true_weight = 100;
+  optional uint64 llvm_profile_false_weight = 101;
+  optional uint64 llvm_profile_total_weight = 102;
 }
 
 message Edge {
@@ -91,4 +99,13 @@ message Edge {
 // A collection of program graphs.
 message ProgramGraphs {
   repeated ProgramGraph graph = 1;
+}
+
+message LlvmProfile {
+  optional uint32 num_functions = 1;
+  optional uint64 max_function_count = 2;
+  optional uint64 num_counts = 10;
+  optional uint32 total_count = 3;
+  optional uint32 max_count = 4;
+  optional uint32 max_internal_count = 5;
 }


### PR DESCRIPTION
This adds optional fields to the ProGraML protocol buffers for recording LLVM profiling information:

**Per-node**
1. `Node.llvm_profile_true_weight` (uint64)
1. `Node.llvm_profile_false_weight` (uint64)
1. `Node.llvm_profile_total_weight` (uint64)
**Per-function**
1. `Function.llvm_entry_count` (uint64)
**Per-graph**
1. `ProgramGraph.LlvmProfile.num_functions` (uint32)
1. `ProgramGraph.LlvmProfile.max_function_count` (uint64)
1. `ProgramGraph.LlvmProfile.num_counts` (uint64)
1. `ProgramGraph.LlvmProfile.total_count` (uint32)
1. `ProgramGraph.LlvmProfile.max_count` (uint32)
1. `ProgramGraph.LlvmProfile.max_internal_count` (uint32)

This information is recorded automatically by llvm2graph during graph construction.