### PR TITLE
Add INSTALL and CONTRIBUTING docs.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,88 @@
+# Contributing
+
+I ❤️ contributions! This project is built *on*, and *for*, open source. If you
+would like to contribute, please read this document.
+
+
+## 1. Reporting Issues
+
+Report issues and bugs to the GitHub issue tracker for this project. I don't
+have requirements for what must go in an issue, I trust use your judgement. At a
+minimum, please include as much information as is required for me to reproduce
+the issue, and copy and paste the output of:
+
+```sh
+$ bazel run //tools:whoami
+```
+
+If you can't use bazel, run the script directly and report its output:
+
+```sh
+$ ./tools/whoami.sh
+```
+
+If you find a bug, by far the best way to report it is to write a test which
+exposes the issue and submit it as a PR. If you can do this, continue reading.
+
+
+## 2. Contributing Code
+
+This project is academic research code. Generally in academia, this means code
+written to a poor standard and provided without tests or documentation. I don't
+like this attitude. I am far from a perfect software engineer, but I strive to
+write clean and maintainable code, and I am always learning. When writing new
+code, use the existing sources as a lower bound on the quality you should be
+aiming for. Specifically:
+
+
+### 2.1. Tests
+
+Please, please, test new code.
+
+To paraphrase Kanye West, "one good test is worth a thousand patches". Use
+bazel's excellent testing infrastructure to run the existing tests, and the new
+ones that you write (see [INSTALL.md](/INSTALL.md) for instructions). Although
+bazel caches test results and will perform only the minimum amount of testing on
+incremental builds, this is a large project with a lot of tests, you may not
+want to run all of them as many will not be relevant to what you are working on.
+Use the CI script provided by bazel to run the tests on only those targets which
+have been modified on your current branch:
+
+```
+$ ./third_party/bazel/ci.sh
+```
+
+
+## 2.2. Code Format
+
+I have strong opinions about code formatting. Not in the specifics of how to
+ident a certain block or where to put the parenthesis around a statement, but
+rather that code formatting should be automated to cognitively offload the
+developer to focus on more important things.
+
+I wrote a tool, [format](https://github.com/ChrisCummins/format), which provides
+automatic code formatters for most of the programming languages used in this
+project. All checked code must pass through the formatters without modification.
+Build and install the `format` binary into `~/.local/bin` using:
+
+```sh
+$ ./tools/format/install.sh
+```
+
+To run the formatter on a specific file, use:
+
+``` sh
+$ format <path...>
+```
+
+However, remembering to run a formatter every time you make an edit is a fool's
+game. Instead, install the provided pre-commit hook to ensure that you never
+miss a run:
+
+```sh
+$ format --install_pre_commit_hook
+```
+
+After installing the pre-commit hook, your commit messages will get a nice
+shiny "Signed off by" footer. Please make sure you have this before submitting
+a Pull Request.

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,0 +1,152 @@
+# Installation
+
+This document describes the requirements and process for building the code
+in this project, along with a list of known issues. Please read through this
+document first if you are encountering problems.
+
+
+## 1. Requirements
+
+This project requires a modern version of Ubuntu Linux or macOS. The core
+dependencies of the project are:
+
+* [Bazel](https://docs.bazel.build/versions/master/install.html) >= 2.0.0.
+* Python >= 3.6.
+* A modern C++ toolchain with support for (at least) C++14.
+
+#### Building with Docker
+
+I maintain a docker image
+[chriscummins/phd_build](https://hub.docker.com/r/chriscummins/phd_build)
+which is a pre-configured Linux distribution with all build dependencies for
+this project. If you are using an unsupported system, or if you don't have the
+necessary privileges to install the depenencies, you can use this image to run
+all of your builds and tests:
+
+```sh
+$ PHD="$(pwd)" bash tools/docker/phd_build/run.sh
+```
+
+This will drop you into a bash prompt from which you can run builds and tests,
+saving you the need to install any dependencies on your host system. Note that
+this image is large (sorry about that, LaTeX distributions are huge), and the
+symlinks that bazel creates for `bazel-bin` and the like may be replaced.
+
+
+#### Additional dependencies
+
+Many sub-projects have additional build-time or runtime dependencies, such as
+docker, Java, or go. On a supported system, run the following script to generate
+a script which will exhaustively installs all dependencies:
+
+``` sh
+$ ./tools/make_bootstrap.sh
+```
+
+This will create a file `bootstrap.sh`. Inspect this script, and if it looks
+good to you, run it.
+
+
+## 2. Building the code
+
+This project uses the bazel build system. I'm a big fan of bazel, but there's
+no denying that it has some quirks. If you are unfamiliar with it, I would
+suggest having a quick flick through
+[the docs](https://docs.bazel.build/versions/master/build-ref.html) to
+understand the basic terminology and design decisions, it's probably unlike any
+build system you have used before. The core commands you will use are `run` and
+`test`.
+
+#### bazel run //path/to:target
+
+This builds the specified target and executes it. A few things to be aware of:
+
+* Command line flags which you intend to pass to the executable need to be
+  escaped with `--` to prevent bazel from attempting to interpret them, e.g.
+  `bazel run //path/to:target -- --flag=foo`.
+* Almost every executable target in this project provides documentation and
+  usage information using the `--help` flag. Try it!
+  `bazel run //path/to:target -- --help`.
+* Bazel defaults to a debug build for quicker compiles. To build an optimized
+  executable, use the `-c opt` option, e.g. `bazel run -c opt //path/to:target`.
+* Bazel ignores most of your environment set up and runs executables in a
+  different working directory. Use full paths when referencing files:
+  `bazel run //path/to:target -- --read_from=/tmp/file.txt`.
+
+#### bazel test //path/to/targets
+
+This builds and executes one or more test targets. Bazel provides a sandboxed
+testing environment and caches the results of tests. A path ending in `...` is
+interpreted as a wildcard to match all targets below the specified package.
+For example, to run the entire set of tests in this project, run:
+
+``` sh
+$ bazel test //...
+```
+
+Note that there are many thousands of tests in this project and running them
+all may take a few hours. You probably only want to run the tests for the
+particular package that you are interested in using.
+
+#### bazel query
+
+Whilst not strictly necessary for building and running code, `bazel query` is
+a phenominally useful tool for finding your way around the codebase.
+
+For example, you can list all of the executable targets in this project using:
+
+```sh
+$ bazel query 'kind(".*_binary",//...)'
+```
+
+Or if you are, say, working on the target `//package:foo` and what to see what
+other targets will be affected by this change, run:
+
+```sh
+$ bazel query 'rdeps(//..., //package:foo)'
+```
+
+I would suggest taking a look at the
+[bazel query docs](https://docs.bazel.build/versions/master/query.html)
+for further details.
+
+
+## 3. Known Issues
+
+Maintaining a large project with numerous third-party dependencies is a
+never-ending challenge. This section summarizes some of the key known issues
+around building the code. Please check here first if you encounter an error in
+the build.
+
+
+#### Non-standard $PATH
+
+The script `tools/bazel` specifies the environment in which bazel executes. It
+sets only a handful of environment variables and uses common default values for
+your `$PATH`. If you have installed dependencies in a non-standard path, such
+as when using a python virtualenv, you may need to modify this script so that
+bazel can find the right dependencies.
+
+
+#### Tensorflow
+
+The pip-installed Tensorflow dependency currently doesn't work as a result of
+a bug in a dependency:
+[rules_python#71](https://github.com/bazelbuild/rules_python/issues/71). To see
+if you are affected, run:
+
+```sh
+$ bazel run //third_party/py/tensorflow:smoke_test
+```
+
+If the above test fails, you are affected. The workaround is to install the
+version of Tensorflow specified in
+`requirements.txt` into the system python packages, e.g.:
+
+```sh
+$ python3 -m pip install "tensorflow-gpu==1.14.0"
+```
+
+A symptom of this issue that you may experience breakages if you already have a
+system version of Tensorflow which is incompatible with the one expected by this
+project.

--- a/tools/source_tree/phd_workspace.py
+++ b/tools/source_tree/phd_workspace.py
@@ -25,7 +25,9 @@ _ALWAYS_EXPORTED_FILES = [
   "configure",  # Needed to generate config proto.
   "BUILD",  # Top-level BUILD file is always needed.
   "WORKSPACE",  # Implicit dependency of everything.
-  "README.md",
+  "README.md",  # Core documentation.
+  "INSTALL.md",  # Core documentation.
+  "CONTRIBUTING.md",  # Core documentation.
   "requirements.txt",  # Needed by WORKSPACE.
   "tools/Brewfile.travis",  # Needed by Travis CI.
   "tools/bazel",  # Optional, but useful.


### PR DESCRIPTION
This project uses a build system which may be unfamiliar to many users
and has a number of significant dependencies and "gotchas". Despite
that, my documentation has been somewhat ... rubbish.

These two docs aim to begin addressing this issue. I'm sure there are
improvements that will need to be made as I find out more about what
others are struggling with and what information I can provide to help
get users up and running.