### PR TITLE
ml4pl/llvm2graph: Add support for struct inlining

### DIFF
--- a/deeplearning/ml4pl/graphs/llvm2graph/BUILD
+++ b/deeplearning/ml4pl/graphs/llvm2graph/BUILD
@@ -146,6 +146,7 @@ py_binary(
         "//labm8/py:app",
         "//labm8/py:bazelutil",
         "//labm8/py:decorators",
+        "//labm8/py:fs",
         "//third_party/py/numpy",
     ],
 )

--- a/deeplearning/ncc/inst2vec/inst2vec_preprocess.py
+++ b/deeplearning/ncc/inst2vec/inst2vec_preprocess.py
@@ -25,6 +25,7 @@ import copy
 import os
 import pickle
 import re
+from typing import Dict
 
 import networkx as nx
 
@@ -2957,6 +2958,21 @@ def inline_struct_types_in_file(G, dic, specific_struct_name_pattern):
             )
 
   return G
+
+
+def GetStructTypes(ir: str) -> Dict[str, str]:
+  """Extract a dictionary of struct definitions from the given IR.
+
+  Args:
+    ir: A string of LLVM IR.
+
+  Returns:
+    A dictionary of <name, def> entries, where <name> is the name of a struct
+    definition (e.g. "%struct.foo"), and <def> is the definition of the member
+    types, e.g. "{ i32 }".
+  """
+  _, dict_temp = construct_struct_types_dictionary_for_file(ir.split("\n"))
+  return dict_temp
 
 
 def inline_struct_types(

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -2,6 +2,10 @@
 # Some of these scripts are meant for execution in-tree, and cannot be run
 # using bazel, please see the comments.
 
+exports_files([
+    "bazel",
+])
+
 sh_binary(
     name = "whoami",
     srcs = ["whoami.sh"],

--- a/tools/bazel
+++ b/tools/bazel
@@ -55,6 +55,9 @@ path_dirs=( \
 if [[ -f "/usr/local/opt/llvm/bin/clang" ]]; then
   CC=/usr/local/opt/llvm/bin/clang
   CXX=/usr/local/opt/llvm/bin/clang++
+else
+  CC="$(which gcc)"
+  CXX="$(which g++)"
 fi
 
 # PULLET_TIMEOUT to increase the timeout on docker image pulls from the default

--- a/tools/bazel
+++ b/tools/bazel
@@ -21,6 +21,49 @@
 # Your mileage may vary.
 set -eu
 
+build_path() {
+    local _dir=""
+    local _path=""
+
+    for _dir in "$@"
+    do
+        if [ -d $_dir ]; then
+            _path=$_path:$_dir
+        fi
+    done
+
+    _path=${_path:1}
+    echo $_path
+}
+
+# Accepts an array of directories and returns a colon separated path
+# of all of the directories that exist, in order.  Example usage:
+#
+#    dirs=("/usr/local/bin" /usr/bin "/not a real path")
+#    unset FOO
+#    FOO=$(build_path "${dirs[@]}")
+#    echo $FOO
+#    # Outputs: /usr/local/bin:/usr/bin
+path_dirs=( \
+    /usr/local/opt/llvm/bin \
+    /usr/local/opt/gnu-sed/libexec/gnubin \
+    /usr/bin \
+    /usr/local/bin \
+    /bin \
+)
+
+if [[ -f "/usr/local/opt/llvm/bin/clang" ]]; then
+  CC=/usr/local/opt/llvm/bin/clang
+  CXX=/usr/local/opt/llvm/bin/clang++
+fi
+
 # PULLET_TIMEOUT to increase the timeout on docker image pulls from the default
 # 600s. See: https://github.com/bazelbuild/rules_docker
-env -i TERM="$TERM" PATH=/usr/local/opt/gnu-sed/libexec/gnubin:/usr/bin:/usr/local/bin:/bin PULLER_TIMEOUT=3600 "$BAZEL_REAL" "$@"
+set +u
+env -i \
+  TERM="$TERM" \
+  PATH="$(build_path ${path_dirs[@]})" \
+  CC=$CC \
+  CXX=$CXX \
+  PULLER_TIMEOUT=3600 \
+  "$BAZEL_REAL" "$@"


### PR DESCRIPTION
This adds support for inlining struct definitions in IR statements, so
that:

    %struct.bar = type { i32 }
    %2 = alloca %struct.bar*, align 8

is inlined to:

    <%ID> = alloca { i32 }*, align 8

To achieve this, the original IR file is required during node encoding
so that we can use inst2vec's existing struct extractor function,
followed by a rewriting pass on the IR statements in the graph.

I added a `--ir` flag to `//deeplearning/ml4pl/graphs/llvm2graph:node_encoder`
so that you can specify the IR file to read struct definitions from. This
flag is optional - if omitted, struct inling is not done.

The struct inlining is done using simple string manipulation and
likely has corner cases and bugs. In the future we should replace this
fragile method with an implementation using the parsed llvm::Module
during llvm2graph graph construction.

github.com/ChrisCummins/ProGraML/issues/57