### PR TITLE
ml4pl: Make call edges all have position 0.

### DIFF
--- a/deeplearning/ml4pl/graphs/graph_builder.cc
+++ b/deeplearning/ml4pl/graphs/graph_builder.cc
@@ -91,7 +91,7 @@ void GraphBuilder::AddCallEdge(int sourceNode, int destinationNode) {
         graph_.node(destinationNode).type() == Node::STATEMENT)
       << "Call edge must connect statements";
 
-  call_adjacencies_[sourceNode].push_back(destinationNode);
+  call_adjacencies_[sourceNode].insert(destinationNode);
 }
 
 void GraphBuilder::AddDataEdge(int sourceNode, int destinationNode,
@@ -139,6 +139,24 @@ void GraphBuilder::AddEdges(const std::vector<std::vector<size_t>>& adjacencies,
       edge->set_source_node(sourceNode);
       edge->set_destination_node(destinationNode);
       edge->set_position(position);
+
+      // Record the source and destination nodes in the node set.
+      (*visitedNodes)[sourceNode] = true;
+      (*visitedNodes)[destinationNode] = true;
+    }
+  }
+}
+
+void GraphBuilder::AddEdges(
+    const std::vector<absl::flat_hash_set<size_t>>& adjacencies,
+    const Edge::Flow& flow, std::vector<bool>* visitedNodes) {
+  for (size_t sourceNode = 0; sourceNode < adjacencies.size(); ++sourceNode) {
+    for (size_t destinationNode : adjacencies[sourceNode]) {
+      Edge* edge = graph_.add_edge();
+      edge->set_flow(flow);
+      edge->set_source_node(sourceNode);
+      edge->set_destination_node(destinationNode);
+      edge->set_position(0);
 
       // Record the source and destination nodes in the node set.
       (*visitedNodes)[sourceNode] = true;

--- a/deeplearning/ml4pl/graphs/graph_builder.h
+++ b/deeplearning/ml4pl/graphs/graph_builder.h
@@ -20,6 +20,7 @@
 #include <vector>
 
 #include "absl/container/flat_hash_map.h"
+#include "absl/container/flat_hash_set.h"
 #include "deeplearning/ml4pl/graphs/programl.pb.h"
 #include "labm8/cpp/string.h"
 
@@ -45,10 +46,15 @@ class GraphBuilder {
   std::pair<int, Node*> AddImmediate(const string& text);
 
   // Edge factories.
+
+  // Add a control edge. Control edges are given a position automatically by
+  // order in which they are added.
   void AddControlEdge(int sourceNode, int destinationNode);
 
+  // Add a call edge. Call edges always have 0 position.
   void AddCallEdge(int sourceNode, int destinationNode);
 
+  // Add a data edge with the given position.
   void AddDataEdge(int sourceNode, int destinationNode, int position);
 
   // Access the graph.
@@ -75,7 +81,12 @@ class GraphBuilder {
  private:
   ProgramGraph graph_;
 
+  // Add a positional list of edges.
   void AddEdges(const std::vector<std::vector<size_t>>& adjacencies,
+                const Edge::Flow& flow, std::vector<bool>* visitedNodes);
+
+  // Add an unordered set of edges. All edges have position 0.
+  void AddEdges(const std::vector<absl::flat_hash_set<size_t>>& adjacencies,
                 const Edge::Flow& flow, std::vector<bool>* visitedNodes);
 
   void AddReverseEdges(
@@ -85,7 +96,7 @@ class GraphBuilder {
   // Adjacency lists.
   std::vector<std::vector<size_t>> control_adjacencies_;
   std::vector<std::vector<std::pair<size_t, int>>> data_reverse_adjacencies_;
-  std::vector<std::vector<size_t>> call_adjacencies_;
+  std::vector<absl::flat_hash_set<size_t>> call_adjacencies_;
 
   bool finalized_;
 };


### PR DESCRIPTION
This changes the behavior of the graph builder such that call edges
all have a position of 0. This is to match our design intent - there
is no "ordering" of call edges, unlike with data or control edges.