### PR TITLE
Update cldrive docs and add Travis CI

### DIFF
--- a/gpu/cldrive/README.md
+++ b/gpu/cldrive/README.md
@@ -17,13 +17,15 @@ Install [Bazel](https://docs.bazel.build/versions/master/install.html).
 Build using:
 
 ```sh
-$ bazel build //gpu/cldrive
+$ bazel build -c opt //gpu/cldrive
 ```
+
+This will build an optimized `cldrive` binary and print its path.
 
 ## Usage
 
 ```sh
-$ bazel run //gpu/cldrive -- --srcs=<opencl_sources> --envs=<opencl_devices>
+$ cldrive --srcs=<opencl_sources> --envs=<opencl_devices>
 ```
 
 Where `<opencl_sources>` if a comma separated list of absolute paths to OpenCL
@@ -47,7 +49,7 @@ kernel void my_kernel(global int* a, global int* b) {
 and available OpenCL devices:
 
 ```sh
-$ bazel run //gpu/cldrive -- --clinfo
+$ cldrive --clinfo
 GPU|NVIDIA|GeForce_GTX_1080|396.37|1.2
 CPU|Intel|Intel_Xeon_CPU_E5-2620_v4_@_2.10GHz|1.2.0.25|2.0
 ```
@@ -56,7 +58,7 @@ To run the kernel 5 times on both devices using 4096 work items divided into
 work groups of size 1024:
 
 ```sh
-$ bazel run //gpu/cldrive -- --srcs=$PWD/kernel.cl --num_runs=5 \
+$ cldrive --srcs=$PWD/kernel.cl --num_runs=5 \
     --gsize=4096 --lsize=1024 \
     --envs='GPU|NVIDIA|GeForce_GTX_1080|396.37|1.2','CPU|Intel|Intel_Xeon_CPU_E5-2620_v4_@_2.10GHz|1.2.0.25|2.0'
 OpenCL Device, Kernel Name, Global Size, Local Size, Transferred Bytes, Runtime (ns)

--- a/gpu/cldrive/README.md
+++ b/gpu/cldrive/README.md
@@ -1,5 +1,9 @@
 # cldrive - Run arbitrary OpenCL kernels
 
+<!-- Travis CI -->
+<a href="https://travis-ci.org/ChrisCummins/cldrive">
+  <img src="https://img.shields.io/travis/ChrisCummins/cldrive/master.svg">
+</a>
 <!-- Better code -->
 <a href="https://bettercodehub.com/results/ChrisCummins/cldrive">
   <img src="https://bettercodehub.com/edge/badge/ChrisCummins/cldrive?branch=master">

--- a/gpu/cldrive/README.md
+++ b/gpu/cldrive/README.md
@@ -13,12 +13,33 @@
   <img src="https://img.shields.io/badge/license-GNU%20GPL%20v3-blue.svg?style=flat">
 </a>
 
+[cldrive](https://github.com/ChrisCummins/cldrive) is a tool for running
+arbitrary OpenCL kernels to record their runtimes and outputs. It reads OpenCL
+kernels from an input file, and for each, generates random inputs
+(parameterized by a given size), runs the kernel and records its execution time
+and outputs. It was developed as part of my work on
+[Deep Learning benchmark synthesis](https://github.com/ChrisCummins/clgen), and
+has been used in the following publications:
 
-## Prerequisites
+1. Cummins, C., Petoumenos, P., Zang, W., & Leather, H. (2017). Synthesizing
+   Benchmarks for Predictive Modeling. CGO. IEEE.
+1. Cummins, C., Petoumenos, P., Wang, Z., & Leather, H. (2017). End-to-end
+   Deep Learning of Optimization Heuristics. PACT. IEEE.
+1. Ben-Nun, T., Jakobovits, A. S., & Hoefler, T. (2018). Neural Code
+   Comprehension: A Learnable Representation of Code Semantics. NeurIPS.
+1. Cummins, C., Petoumenos, P., Murray, A., & Leather, H. (2018). Compiler
+   Fuzzing through Deep Learning. ISSTA.
+1. Goens, A., Brauckmann, A., Ertel, S., Cummins, C., Leather, H., &
+   Castrillon, J. (2019). A Case Study on Machine Learning for Synthesizing
+   Benchmarks. MAPL.
+1. Cummins, C. (2020). Deep Learning for Compilers. University of Edinburgh.
 
-Install [Bazel](https://docs.bazel.build/versions/master/install.html).
+## Build
 
-Build using:
+See [INSTALL.md](/INSTALL.md) for instructions on setting up the build
+environment.
+
+Then build cldrive using:
 
 ```sh
 $ bazel build -c opt //gpu/cldrive

--- a/gpu/cldrive/travis.yml
+++ b/gpu/cldrive/travis.yml
@@ -1,1 +1,32 @@
-# TODO
+# Run //gpu/cldrive/... test suite using phd_build docker image.
+language: generic
+
+services:
+  - docker
+
+install:
+  - docker pull chriscummins/phd_build:latest
+  - chmod -R 777 $TRAVIS_BUILD_DIR
+
+script:
+  - >
+    docker run \
+        -u root \
+        -v$TRAVIS_BUILD_DIR:/phd \
+        -v/var/run/docker.sock:/var/run/docker.sock \
+        -v$HOME/.cache/bazel/_bazel_docker:/home/docker/.cache/bazel/_bazel_docker \
+        chriscummins/phd_build:latest \
+        -c "./tools/flaky_bazel.sh run --config=travis //tools:whoami"
+  - >
+    docker run \
+        -u root \
+        -v$TRAVIS_BUILD_DIR:/phd \
+        -v/var/run/docker.sock:/var/run/docker.sock \
+        -v$HOME/.cache/bazel/_bazel_docker:/home/docker/.cache/bazel/_bazel_docker \
+        chriscummins/phd_build:latest \
+        -c "./tools/flaky_bazel.sh test //gpu/cldrive/..."
+
+notifications:
+  email:
+    on_success: never
+    on_failure: change

--- a/tools/source_tree/phd_workspace.py
+++ b/tools/source_tree/phd_workspace.py
@@ -21,20 +21,22 @@ FLAGS = app.FLAGS
 # patterns are expanded.
 _ALWAYS_EXPORTED_FILES = [
   ".bazelrc",  # Not strictly required, but provides consistency.
-  "configure",  # Needed to generate config proto.
   "BUILD",  # Top-level BUILD file is always needed.
-  "WORKSPACE",  # Implicit dependency of everything.
-  "README.md",  # Core documentation.
-  "INSTALL.md",  # Core documentation.
+  "configure",  # Needed to generate config proto.
   "CONTRIBUTING.md",  # Core documentation.
+  "INSTALL.md",  # Core documentation.
+  "README.md",  # Core documentation.
   "requirements.txt",  # Needed by WORKSPACE.
-  "tools/Brewfile.travis",  # Needed by Travis CI.
-  "tools/bazel",  # Optional, but useful.
-  "tools/bzl/*",  # Implicit dependency of WORKSPACE file.
-  "third_party/bazel/*",  # Needed by WORKSPACE.
   "third_party/*.BUILD",  # Implicit dependencies of WORKSPACE file.
+  "third_party/bazel/*",  # Needed by WORKSPACE.
+  "third_party/py/*.bzl",  # Implicit dependencies of WORKSPACE file.
+  "third_party/py/*.tpl",  # Implicit dependencies of WORKSPACE file.
+  "tools/bazel",  # Optional, but useful.
+  "tools/Brewfile.travis",  # Needed by Travis CI.
+  "tools/bzl/*",  # Implicit dependency of WORKSPACE file.
   "tools/flaky_bazel.sh",  # Needed by Travis CI.
   "tools/workspace_status.sh",  # Needed by .bazelrc
+  "WORKSPACE",  # Implicit dependency of everything.
 ]
 
 # A list of relative paths to files which are excluded from export. Glob


### PR DESCRIPTION
This improves the README for cldrive and adds a Travis CI config which runs the `//gpu/cldrive/...` test suite.