### PR TITLE
programl: Update LLVM version to 10.0.0.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -137,6 +137,17 @@ http_archive(
 # LLVM.
 
 http_archive(
+    name = "llvm",
+    sha256 = "f90de64a5827690bfb20a5a852f42cc484fd8826f7ea7135bc9d7d31b262174f",
+    strip_prefix = "bazel_llvm-20834c602493b95b4cb23214c1731776a4f24596",
+    urls = ["https://github.com/ChrisCummins/bazel_llvm/archive/20834c602493b95b4cb23214c1731776a4f24596.tar.gz"],
+)
+
+load("@llvm//tools/bzl:deps.bzl", "llvm_deps")
+
+llvm_deps()
+
+http_archive(
     name = "llvm_mac",
     build_file = "//:third_party/llvm.BUILD",
     sha256 = "0ef8e99e9c9b262a53ab8f2821e2391d041615dd3f3ff36fdf5370916b0f4268",

--- a/programl/BUILD
+++ b/programl/BUILD
@@ -58,10 +58,10 @@ sh_binary(
         "//programl/cmd:xla2graph",
     ] + select({
         "//:darwin": [
-            "@llvm_mac//:libs",
+            "@clang-llvm-10.0.0-x86_64-apple-darwin//:libs",
         ],
         "//conditions:default": [
-            "@llvm_linux//:libs",
+            "@clang-llvm-10.0.0-x86_64-linux-gnu-ubuntu-18.04//:libs",
         ],
     }),
 )

--- a/programl/Documentation/cmd/clang2graph.txt
+++ b/programl/Documentation/cmd/clang2graph.txt
@@ -1,11 +1,11 @@
 OVERVIEW: clang frontend for ProGraML
 
-USAGE: clang2graph [options] <inputs>
+USAGE: clang2graph [options] file...
 
 OPTIONS:
   -###                    Print (but do not run) the commands to run for this compilation
   --analyzer-output <value>
-                          Static analyzer report output format (html|plist|plist-multi-file|plist-html|text).
+                          Static analyzer report output format (html|plist|plist-multi-file|plist-html|sarif|text).
   --analyze               Run the static analyzer
   -arcmt-migrate-emit-errors
                           Emit ARC errors even if the migrator can fix them
@@ -26,6 +26,8 @@ OPTIONS:
                           OpenCL only. Treat double precision floating-point constant as single precision constant.
   -cl-std=<value>         OpenCL language standard to compile for.
   -cl-strict-aliasing     OpenCL only. This option is added for compatibility with OpenCL 1.0.
+  -cl-uniform-work-group-size
+                          OpenCL only. Defines that the global work-size be a multiple of the work-group size specified to clEnqueueNDRangeKernel
   -cl-unsafe-math-optimizations
                           OpenCL only. Allow unsafe floating-point optimizations.  Also implies -cl-no-signed-zeros and -cl-mad-enable.
   --config <value>        Specifies configuration file
@@ -34,8 +36,11 @@ OPTIONS:
   --cuda-device-only      Compile CUDA code for device only
   --cuda-gpu-arch=<value> CUDA GPU architecture (e.g. sm_35).  May be specified more than once.
   --cuda-host-only        Compile CUDA code for host only.  Has no effect on non-CUDA compilations.
+  --cuda-include-ptx=<value>
+                          Include PTX for the following GPU architecture (e.g. sm_35) or 'all'. May be specified more than once.
   --cuda-noopt-device-debug
                           Enable device-side debug info generation. Disables ptxas optimizations.
+  --cuda-path-ignore-env  Ignore environment variables to detect CUDA installation
   --cuda-path=<value>     CUDA installation path
   -cxx-isystem <directory>
                           Add directory to the C++ SYSTEM include search path
@@ -49,13 +54,19 @@ OPTIONS:
   -dM                     Print macro definitions in -E mode instead of normal output
   -D <macro>=<value>      Define <macro> to <value> (or 1 if <value> omitted)
   -emit-ast               Emit Clang AST files for source inputs
+  -emit-interface-stubs   Generate Inteface Stub Files.
   -emit-llvm              Use the LLVM representation for assembler and object files
+  -emit-merged-ifs        Generate Interface Stub Files, emit merged text not binary.
+  -enable-trivial-auto-var-init-zero-knowing-it-will-be-removed-from-clang
+                          Trivial automatic variable initialization to zero is only here for benchmarks, it'll eventually be removed, and I'm OK with that because I'm only using it to benchmark
   -E                      Only run the preprocessor
+  -faddrsig               Emit an address-significance table
   -faligned-allocation    Enable C++17 aligned allocation functions
   -fallow-editor-placeholders
                           Treat editor placeholders as valid source code
   -fansi-escape-codes     Use ANSI escape codes for diagnostics
   -fapple-kext            Use Apple's kernel extensions ABI
+  -fapple-link-rtlib      Force linking the clang builtins runtime library
   -fapple-pragma-pack     Enable Apple gcc-compatible #pragma pack handling
   -fapplication-extension Restrict code to those available for App Extensions
   -fblocks                Enable the 'blocks' language feature
@@ -65,28 +76,57 @@ OPTIONS:
   -fbuild-session-timestamp=<time since Epoch in seconds>
                           Time when the current build session started
   -fbuiltin-module-map    Load the clang builtins module map file.
+  -fc++-static-destructors
+                          Enable C++ static destructor registration (the default)
+  -fcall-saved-x10        Make the x10 register call-saved (AArch64 only)
+  -fcall-saved-x11        Make the x11 register call-saved (AArch64 only)
+  -fcall-saved-x12        Make the x12 register call-saved (AArch64 only)
+  -fcall-saved-x13        Make the x13 register call-saved (AArch64 only)
+  -fcall-saved-x14        Make the x14 register call-saved (AArch64 only)
+  -fcall-saved-x15        Make the x15 register call-saved (AArch64 only)
+  -fcall-saved-x18        Make the x18 register call-saved (AArch64 only)
+  -fcall-saved-x8         Make the x8 register call-saved (AArch64 only)
+  -fcall-saved-x9         Make the x9 register call-saved (AArch64 only)
+  -fcf-protection=<value> Instrument control-flow architecture protection. Options: return, branch, full, none.
+  -fcf-protection         Enable cf-protection in 'full' mode
+  -fchar8_t               Enable C++ builtin type char8_t
   -fclang-abi-compat=<version>
                           Attempt to match the ABI of Clang <version>
   -fcolor-diagnostics     Use colors in diagnostics
   -fcomment-block-commands=<arg>
                           Treat each comma separated argument in <arg> as a documentation comment block command
+  -fcomplete-member-pointers
+                          Require member pointer base types to be complete if they would be significant under the Microsoft ABI
+  -fconvergent-functions  Assume functions may be convergent
   -fcoroutines-ts         Enable support for the C++ Coroutines TS
   -fcoverage-mapping      Generate coverage mapping to enable code coverage analysis
+  -fcs-profile-generate=<directory>
+                          Generate instrumented code to collect context sensitive execution counts into <directory>/default.profraw (overridden by LLVM_PROFILE_FILE env var)
+  -fcs-profile-generate   Generate instrumented code to collect context sensitive execution counts into default.profraw (overridden by LLVM_PROFILE_FILE env var)
   -fcuda-approx-transcendentals
                           Use approximate transcendental functions
   -fcuda-flush-denormals-to-zero
                           Flush denormal floating point values to zero in CUDA device mode.
+  -fcuda-short-ptr        Use 32-bit pointers for accessing const/local/shared address spaces.
   -fcxx-exceptions        Enable C++ exceptions
   -fdata-sections         Place each data in its own section (ELF Only)
+  -fdebug-compilation-dir <value>
+                          The compilation directory to embed in the debug info.
+  -fdebug-default-version=<value>
+                          Default DWARF version to use, if a -g option caused DWARF debug info to be produced
   -fdebug-info-for-profiling
                           Emit extra debug info to make sample profile more accurate.
   -fdebug-macro           Emit macro debug information
   -fdebug-prefix-map=<value>
                           remap file source paths in debug info
+  -fdebug-ranges-base-address
+                          Use DWARF base address selection entries in debug_ranges
   -fdebug-types-section   Place debug types in their own section (ELF Only)
   -fdeclspec              Allow __declspec as a keyword
   -fdelayed-template-parsing
                           Parse templated function definitions at the end of the translation unit
+  -fdelete-null-pointer-checks
+                          Treat usage of null pointers as undefined behavior.
   -fdiagnostics-absolute-paths
                           Print absolute paths in diagnostics
   -fdiagnostics-hotness-threshold=<number>
@@ -103,6 +143,8 @@ OPTIONS:
                           Print option name with mappable diagnostics
   -fdiagnostics-show-template-tree
                           Print a template comparison tree for differing templates
+  -fdigraphs              Enable alternative token representations '<:', ':>', '<%', '%>', '%:', '%:%:' (default)
+  -fdiscard-value-names   Discard value names in LLVM IR
   -fdollars-in-identifiers
                           Allow '$' in identifiers
   -fdouble-square-bracket-attributes
@@ -116,19 +158,65 @@ OPTIONS:
   -femulated-tls          Use emutls functions to access thread_local variables
   -fexceptions            Enable support for exception handling
   -fexperimental-isel     Enables the experimental global instruction selector
+  -fexperimental-new-constant-interpreter
+                          Enable the experimental new constant interpreter
   -fexperimental-new-pass-manager
                           Enables an experimental new pass manager in LLVM.
   -ffast-math             Allow aggressive, lossy floating-point optimizations
+  -ffile-prefix-map=<value>
+                          remap file source paths in debug info and predefined preprocessor macros
   -ffine-grained-bitfield-accesses
-                          Use separate accesses for bitfields with legal widths and alignments.
+                          Use separate accesses for consecutive bitfield runs with legal widths and alignments.
+  -ffixed-point           Enable fixed point types
+  -ffixed-r19             Reserve register r19 (Hexagon only)
   -ffixed-r9              Reserve the r9 register (ARM only)
-  -ffixed-x18             Reserve the x18 register (AArch64 only)
-  -ffp-contract=<value>   Form fused FP ops (e.g. FMAs): fast (everywhere) | on (according to FP_CONTRACT pragma, default) | off (never fuse)
+  -ffixed-x10             Reserve the 10 register (AArch64/RISC-V only)
+  -ffixed-x11             Reserve the 11 register (AArch64/RISC-V only)
+  -ffixed-x12             Reserve the 12 register (AArch64/RISC-V only)
+  -ffixed-x13             Reserve the 13 register (AArch64/RISC-V only)
+  -ffixed-x14             Reserve the 14 register (AArch64/RISC-V only)
+  -ffixed-x15             Reserve the 15 register (AArch64/RISC-V only)
+  -ffixed-x16             Reserve the 16 register (AArch64/RISC-V only)
+  -ffixed-x17             Reserve the 17 register (AArch64/RISC-V only)
+  -ffixed-x18             Reserve the 18 register (AArch64/RISC-V only)
+  -ffixed-x19             Reserve the 19 register (AArch64/RISC-V only)
+  -ffixed-x1              Reserve the 1 register (AArch64/RISC-V only)
+  -ffixed-x20             Reserve the 20 register (AArch64/RISC-V only)
+  -ffixed-x21             Reserve the 21 register (AArch64/RISC-V only)
+  -ffixed-x22             Reserve the 22 register (AArch64/RISC-V only)
+  -ffixed-x23             Reserve the 23 register (AArch64/RISC-V only)
+  -ffixed-x24             Reserve the 24 register (AArch64/RISC-V only)
+  -ffixed-x25             Reserve the 25 register (AArch64/RISC-V only)
+  -ffixed-x26             Reserve the 26 register (AArch64/RISC-V only)
+  -ffixed-x27             Reserve the 27 register (AArch64/RISC-V only)
+  -ffixed-x28             Reserve the 28 register (AArch64/RISC-V only)
+  -ffixed-x29             Reserve the 29 register (AArch64/RISC-V only)
+  -ffixed-x2              Reserve the 2 register (AArch64/RISC-V only)
+  -ffixed-x30             Reserve the 30 register (AArch64/RISC-V only)
+  -ffixed-x31             Reserve the 31 register (AArch64/RISC-V only)
+  -ffixed-x3              Reserve the 3 register (AArch64/RISC-V only)
+  -ffixed-x4              Reserve the 4 register (AArch64/RISC-V only)
+  -ffixed-x5              Reserve the 5 register (AArch64/RISC-V only)
+  -ffixed-x6              Reserve the 6 register (AArch64/RISC-V only)
+  -ffixed-x7              Reserve the 7 register (AArch64/RISC-V only)
+  -ffixed-x8              Reserve the 8 register (AArch64/RISC-V only)
+  -ffixed-x9              Reserve the 9 register (AArch64/RISC-V only)
+  -fforce-dwarf-frame     Always emit a debug frame section
+  -fforce-emit-vtables    Emits more virtual tables to improve devirtualization
+  -fforce-enable-int128   Enable support for int128_t type
+  -ffp-contract=<value>   Form fused FP ops (e.g. FMAs): fast (everywhere) | on (according to FP_CONTRACT pragma) | off (never fuse). Default is 'fast' for CUDA/HIP and 'on' otherwise.
+  -ffp-exception-behavior=<value>
+                          Specifies the exception behavior of floating-point operations.
+  -ffp-model=<value>      Controls the semantics of floating-point calculations.
   -ffreestanding          Assert that the compilation takes place in a freestanding environment
   -ffunction-sections     Place each function in its own section (ELF Only)
   -fgnu-keywords          Allow GNU-extension keywords regardless of language standard
   -fgnu-runtime           Generate output compatible with the standard GNU Objective-C runtime
   -fgnu89-inline          Use the gnu89 inline semantics
+  -fgnuc-version=<value>  Sets various macros to claim compatibility with the given GCC version (default is 4.2.1)
+  -fgpu-allow-device-init Allow device side init function in HIP
+  -fgpu-rdc               Generate relocatable device code, also known as separate compilation mode.
+  -fhip-new-launch-api    Use new kernel launching API for HIP.
   -fimplicit-module-maps  Implicitly search the file system for module map files.
   -finline-functions      Inline suitable functions
   -finline-hint-functions Inline functions which are (explicitly or implicitly) marked inline
@@ -138,12 +226,19 @@ OPTIONS:
                           Like -finstrument-functions, but insert the calls after inlining
   -finstrument-functions  Generate calls to instrument function entry and exit
   -fintegrated-as         Enable the integrated assembler
+  -fintegrated-cc1        Run cc1 in-process
+  -fkeep-static-consts    Keep static const variables even if unused
+  -flax-vector-conversions=<value>
+                          Enable implicit vector bit-casts
   -flto-jobs=<value>      Controls the backend parallelism of -flto=thin (default of 0 means the number of threads will be derived from the number of CPUs detected)
   -flto=<value>           Set LTO mode to either 'full' or 'thin'
   -flto                   Enable LTO in 'full' mode
+  -fmacro-prefix-map=<value>
+                          remap file source paths in predefined preprocessor macros
   -fmath-errno            Require math functions to indicate errors by setting errno
   -fmax-type-align=<value>
                           Specify the maximum alignment to enforce on pointers lacking an explicit alignment
+  -fmerge-all-constants   Allow merging of constants
   -fmodule-file=[<name>=]<file>
                           Specify the mapping of module name to precompiled module file, or load a module file if name is omitted.
   -fmodule-map-file=<file>
@@ -166,6 +261,8 @@ OPTIONS:
   -fmodules-ts            Enable support for the C++ Modules TS
   -fmodules-user-build-path <directory>
                           Specify the module user build path
+  -fmodules-validate-input-files-content
+                          Validate PCM input files based on content if mtime differs
   -fmodules-validate-once-per-build-session
                           Don't verify input files for the modules if the module has been successfully validated or loaded during this build session
   -fmodules-validate-system-headers
@@ -178,12 +275,18 @@ OPTIONS:
   -fmsc-version=<value>   Microsoft compiler version number to report in _MSC_VER (0 = don't define it (default))
   -fnew-alignment=<align> Specifies the largest alignment guaranteed by '::operator new(size_t)'
   -fno-access-control     Disable C++ access control
+  -fno-addrsig            Don't emit an address-significance table
   -fno-assume-sane-operator-new
                           Don't assume that C++'s global operator new can't alias any pointer
   -fno-autolink           Disable generation of linker directives for automatic library linking
   -fno-builtin-<value>    Disable implicit builtin knowledge of a specific function
   -fno-builtin            Disable implicit builtin knowledge of functions
+  -fno-c++-static-destructors
+                          Disable C++ static destructor registration
+  -fno-char8_t            Disable C++ builtin type char8_t
   -fno-common             Compile common globals like normal definitions
+  -fno-complete-member-pointers
+                          Do not require member pointer base types to be complete if they would be significant under the Microsoft ABI
   -fno-constant-cfstrings Disable creation of CodeFoundation-type constant strings
   -fno-coverage-mapping   Disable code coverage analysis
   -fno-crash-diagnostics  Disable auto-generation of preprocessed source files and a script for reproduction during a clang crash
@@ -193,8 +296,13 @@ OPTIONS:
   -fno-declspec           Disallow __declspec as a keyword
   -fno-delayed-template-parsing
                           Disable delayed template parsing
+  -fno-delete-null-pointer-checks
+                          Do not treat usage of null pointers as undefined behavior.
   -fno-diagnostics-fixit-info
                           Do not include fixit information in diagnostics
+  -fno-digraphs           Disallow alternative token representations '<:', ':>', '<%', '%>', '%:', '%:%:'
+  -fno-discard-value-names
+                          Do not discard value names in LLVM IR
   -fno-dollars-in-identifiers
                           Disallow '$' in identifiers
   -fno-double-square-bracket-attributes
@@ -206,17 +314,19 @@ OPTIONS:
                           Disables an experimental new pass manager in LLVM.
   -fno-fine-grained-bitfield-accesses
                           Use large-integer access for consecutive bitfield runs.
+  -fno-fixed-point        Disable fixed point types
+  -fno-force-dwarf-frame  Don't always emit a debug frame section
+  -fno-force-enable-int128
+                          Disable support for int128_t type
   -fno-gnu-inline-asm     Disable GNU style inline asm
   -fno-integrated-as      Disable the integrated assembler
+  -fno-integrated-cc1     Spawn a separate process for each cc1
   -fno-jump-tables        Do not use jump tables for lowering switches
-  -fno-lax-vector-conversions
-                          Disallow implicit conversions between vectors with a different number of elements or different element types
   -fno-lto                Disable LTO mode (default)
   -fno-merge-all-constants
                           Disallow merging of constants
   -fno-objc-infer-related-result-type
                           do not infer Objective-C related result type based on method family
-  -fno-openmp-simd        Disable OpenMP code for SIMD-based constructs.
   -fno-operator-names     Do not treat C++ operator name keywords as synonyms for operators
   -fno-plt                Do not use the PLT to make function calls
   -fno-preserve-as-comments
@@ -225,12 +335,21 @@ OPTIONS:
   -fno-profile-instr-generate
                           Disable generation of profile instrumentation.
   -fno-profile-instr-use  Disable using instrumentation data for profile-guided optimization
+  -fno-register-global-dtors-with-atexit
+                          Don't use atexit or __cxa_atexit to register global destructors
   -fno-reroll-loops       Turn off loop reroller
   -fno-rtlib-add-rpath    Do not add -rpath with architecture-specific resource directory to the linker flags
+  -fno-rtti-data          Control emission of RTTI data
   -fno-rtti               Disable generation of rtti information
+  -fno-sanitize-address-poison-custom-array-cookie
+                          Disable poisoning array cookies when using custom operator new[] in AddressSanitizer
   -fno-sanitize-address-use-after-scope
                           Disable use-after-scope detection in AddressSanitizer
+  -fno-sanitize-address-use-odr-indicator
+                          Disable ODR indicator globals
   -fno-sanitize-blacklist Don't use blacklist file for sanitizers
+  -fno-sanitize-cfi-canonical-jump-tables
+                          Do not make the jump table addresses canonical in the symbol table
   -fno-sanitize-cfi-cross-dso
                           Disable control flow integrity (CFI) checks for cross-DSO calls.
   -fno-sanitize-coverage=<value>
@@ -258,33 +377,47 @@ OPTIONS:
   -fno-signed-zeros       Allow optimizations that ignore the sign of floating point zeros
   -fno-spell-checking     Disable spell-checking
   -fno-stack-protector    Disable the use of stack protectors
+  -fno-stack-size-section Don't emit section containing metadata on function stack sizes
   -fno-standalone-debug   Limit debug information produced to reduce size of debug binary
+  -fno-strict-float-cast-overflow
+                          Relax language rules and try to match the behavior of the target's native float-to-int conversion instructions
+  -fno-temp-file          Directly create compilation output files. This may lead to incorrect incremental builds if the compiler crashes
   -fno-threadsafe-statics Do not emit code to make initialization of local statics thread safe
   -fno-trigraphs          Do not process trigraph sequences
   -fno-unroll-loops       Turn off loop unroller
   -fno-use-cxa-atexit     Don't use __cxa_atexit for calling destructors
   -fno-use-init-array     Don't use .init_array instead of .ctors
-  -fnoopenmp-relocatable-target
-                          Do not compile OpenMP target code as relocatable.
   -fobjc-arc-exceptions   Use EH-safe code when synthesizing retains and releases in -fobjc-arc
   -fobjc-arc              Synthesize retain and release calls for Objective-C pointers
   -fobjc-exceptions       Enable Objective-C exceptions
   -fobjc-runtime=<value>  Specify the target Objective-C runtime kind and version
   -fobjc-weak             Enable ARC-style weak references in Objective-C
-  -fopenmp-relocatable-target
-                          OpenMP target code is compiled as relocatable using the -c flag. For OpenMP targets the code is relocatable by default.
   -fopenmp-simd           Emit OpenMP code only for SIMD-based constructs.
   -fopenmp-targets=<value>
                           Specify comma-separated list of triples OpenMP offloading targets to be supported
-  -foptimization-record-file=<value>
-                          Specify the file name of any generated YAML optimization record
+  -fopenmp                Parse OpenMP pragmas and generate parallel code.
+  -foptimization-record-file=<file>
+                          Specify the output name of the file containing the optimization remarks. Implies -fsave-optimization-record. On Darwin platforms, this cannot be used with multiple -arch <arch> options.
+  -foptimization-record-passes=<regex>
+                          Only include passes which match a specified regular expression in the generated optimization record (by default, include all passes)
+  -forder-file-instrumentation
+                          Generate instrumented code to collect order file into default.profraw file (overridden by '=' form of option or LLVM_PROFILE_FILE env var)
   -fpack-struct=<value>   Specify the default maximum struct packing alignment
   -fpascal-strings        Recognize and construct Pascal-style string literals
+  -fpass-plugin=<dsopath> Load pass plugin from a dynamic shared object file (only with new pass manager).
+  -fpatchable-function-entry=<N,M>
+                          Generate M NOPs before function entry and N-M NOPs after function entry
   -fpcc-struct-return     Override the default ABI to return all structs on the stack
+  -fpch-validate-input-files-content
+                          Validate PCH input files based on content if mtime differs
   -fplt                   Use the PLT to make function calls
   -fplugin=<dsopath>      Load the named plugin (dynamic shared object)
   -fprebuilt-module-path=<directory>
                           Specify the prebuilt module path
+  -fprofile-exclude-files=<value>
+                          Instrument only functions from files where names don't match all the regexes separated by a semi-colon
+  -fprofile-filter-files=<value>
+                          Instrument only functions from files where names match any regex separated by a semi-colon
   -fprofile-generate=<directory>
                           Generate instrumented code to collect execution counts into <directory>/default.profraw (overridden by LLVM_PROFILE_FILE env var)
   -fprofile-generate      Generate instrumented code to collect execution counts into default.profraw (overridden by LLVM_PROFILE_FILE env var)
@@ -294,6 +427,8 @@ OPTIONS:
                           Generate instrumented code to collect execution counts into default.profraw file (overridden by '=' form of option or LLVM_PROFILE_FILE env var)
   -fprofile-instr-use=<value>
                           Use instrumentation data for profile-guided optimization
+  -fprofile-remapping-file=<file>
+                          Use the remappings described in <file> to match the profile data against names in the program
   -fprofile-sample-accurate
                           Specifies that the sample profile is accurate
   -fprofile-sample-use=<value>
@@ -302,6 +437,8 @@ OPTIONS:
                           Use instrumentation data for profile-guided optimization. If pathname is a directory, it reads from <pathname>/default.profdata. Otherwise, it reads from file <pathname>.
   -freciprocal-math       Allow division operations to be reassociated
   -freg-struct-return     Override the default ABI to return small structs in registers
+  -fregister-global-dtors-with-atexit
+                          Use atexit or __cxa_atexit to register global destructors
   -frelaxed-template-template-args
                           Enable C++17 relaxed template template argument matching
   -freroll-loops          Turn on loop reroller
@@ -310,16 +447,24 @@ OPTIONS:
                           Level of field padding for AddressSanitizer
   -fsanitize-address-globals-dead-stripping
                           Enable linker dead stripping of globals in AddressSanitizer
+  -fsanitize-address-poison-custom-array-cookie
+                          Enable poisoning array cookies when using custom operator new[] in AddressSanitizer
   -fsanitize-address-use-after-scope
                           Enable use-after-scope detection in AddressSanitizer
+  -fsanitize-address-use-odr-indicator
+                          Enable ODR indicator globals to avoid false ODR violation reports in partially sanitized programs at the cost of an increase in binary size
   -fsanitize-blacklist=<value>
                           Path to blacklist file for sanitizers
+  -fsanitize-cfi-canonical-jump-tables
+                          Make the jump table addresses canonical in the symbol table
   -fsanitize-cfi-cross-dso
                           Enable control flow integrity (CFI) checks for cross-DSO calls.
   -fsanitize-cfi-icall-generalize-pointers
                           Generalize pointers in CFI indirect call type signature checks
   -fsanitize-coverage=<value>
                           Specify the type of coverage instrumentation for Sanitizers
+  -fsanitize-hwaddress-abi=<value>
+                          Select the HWAddressSanitizer ABI to target (interceptor or platform, default interceptor). This option is currently unused.
   -fsanitize-memory-track-origins=<value>
                           Enable origins tracking in MemorySanitizer
   -fsanitize-memory-track-origins
@@ -329,6 +474,8 @@ OPTIONS:
   -fsanitize-recover=<value>
                           Enable recovery for specified sanitizers
   -fsanitize-stats        Enable sanitizer statistics gathering.
+  -fsanitize-system-blacklist=<value>
+                          Path to system blacklist file for sanitizers
   -fsanitize-thread-atomics
                           Enable atomic operations instrumentation in ThreadSanitizer (default)
   -fsanitize-thread-func-entry-exit
@@ -339,6 +486,8 @@ OPTIONS:
   -fsanitize-undefined-strip-path-components=<number>
                           Strip (or keep only, if negative) a given number of path components when emitting check metadata.
   -fsanitize=<check>      Turn on runtime checks for various forms of undefined or suspicious behavior. See user manual for available checks
+  -fsave-optimization-record=<format>
+                          Generate an optimization record file in a specific format
   -fsave-optimization-record
                           Generate a YAML optimization record file
   -fseh-exceptions        Use SEH style exceptions
@@ -349,58 +498,99 @@ OPTIONS:
   -fsized-deallocation    Enable C++14 sized global deallocation functions
   -fsjlj-exceptions       Use SjLj style exceptions
   -fslp-vectorize         Enable the superword-level parallelism vectorization passes
-  -fsplit-dwarf-inlining  Place debug types in their own section (ELF Only)
-  -fstack-protector-all   Force the usage of stack protectors for all functions
+  -fsplit-dwarf-inlining  Provide minimal debug info in the object/executable to facilitate online symbolication/stack traces in the absence of .dwo/.dwp files when using Split DWARF
+  -fsplit-lto-unit        Enables splitting of the LTO unit.
+  -fstack-protector-all   Enable stack protectors for all functions
   -fstack-protector-strong
-                          Use a strong heuristic to apply stack protectors to functions
-  -fstack-protector       Enable stack protectors for functions potentially vulnerable to stack smashing
+                          Enable stack protectors for some functions vulnerable to stack smashing. Compared to -fstack-protector, this uses a stronger heuristic that includes functions containing arrays of any size (and any type), as well as any calls to alloca or the taking of an address from a local variable
+  -fstack-protector       Enable stack protectors for some functions vulnerable to stack smashing. This uses a loose heuristic which considers functions vulnerable if they contain a char (or 8bit integer) array or constant sized calls to alloca, which are of greater size than ssp-buffer-size (default: 8 bytes). All variable sized calls to alloca are considered vulnerable
+  -fstack-size-section    Emit section containing metadata on function stack sizes
   -fstandalone-debug      Emit full debug info for all types used by the program
   -fstrict-enums          Enable optimizations based on the strict definition of an enum's value range
+  -fstrict-float-cast-overflow
+                          Assume that overflowing float-to-int casts are undefined (default)
   -fstrict-return         Always treat control flow paths that fall off the end of a non-void function as unreachable
   -fstrict-vtable-pointers
                           Enable optimizations based on the strict rules for overwriting polymorphic C++ objects
+  -fthin-link-bitcode=<value>
+                          Write minimized bitcode to <file> for the ThinLTO thin link only
   -fthinlto-index=<value> Perform ThinLTO importing using provided function summary index
+  -ftime-trace-granularity=<value>
+                          Minimum time granularity (in microseconds) traced by time profiler
+  -ftime-trace            Turn on time profiler. Generates JSON file based on output filename.
   -ftrap-function=<value> Issue call to specified function rather than a trap instruction
   -ftrapv-handler=<function name>
                           Specify the function to be called on overflow
   -ftrapv                 Trap on integer overflow
   -ftrigraphs             Process trigraph sequences
+  -ftrivial-auto-var-init=<value>
+                          Initialize trivial automatic stack variables: uninitialized (default) | pattern
   -funique-section-names  Use unique names for text and data sections (ELF Only)
   -funroll-loops          Turn on loop unroller
   -fuse-init-array        Use .init_array instead of .ctors
+  -fvalidate-ast-input-files-content
+                          Compute and store the hash of input files used to build an AST. Files with mismatching mtime's are considered valid if both contents is identical
   -fveclib=<value>        Use the given vector functions library
   -fvectorize             Enable the loop vectorization passes
+  -fvirtual-function-elimination
+                          Enables dead virtual function elimination optimization. Requires -flto=full
+  -fvisibility-global-new-delete-hidden
+                          Give global C++ operator new and delete declarations hidden visibility
   -fvisibility-inlines-hidden
-                          Give inline C++ member functions default visibility by default
+                          Give inline C++ member functions hidden visibility by default
   -fvisibility-ms-compat  Give global types 'default' visibility and global functions and variables 'hidden' visibility by default
   -fvisibility=<value>    Set the default symbol visibility for all global declarations
+  -fwasm-exceptions       Use WebAssembly style exceptions
   -fwhole-program-vtables Enables whole-program vtable optimization. Requires -flto
   -fwrapv                 Treat signed integer overflow as two's complement
   -fwritable-strings      Store string literals as writable data
   -fxray-always-emit-customevents
                           Determine whether to always emit __xray_customevent(...) calls even if the function it appears in is not always instrumented.
+  -fxray-always-emit-typedevents
+                          Determine whether to always emit __xray_typedevent(...) calls even if the function it appears in is not always instrumented.
   -fxray-always-instrument= <value>
-                          Filename defining the whitelist for imbuing the 'always instrument' XRay attribute.
+                          DEPRECATED: Filename defining the whitelist for imbuing the 'always instrument' XRay attribute.
+  -fxray-attr-list= <value>
+                          Filename defining the list of functions/types for imbuing XRay attributes.
   -fxray-instruction-threshold= <value>
                           Sets the minimum function size to instrument with XRay
+  -fxray-instrumentation-bundle= <value>
+                          Select which XRay instrumentation points to emit. Options: all, none, function, custom. Default is 'all'.
   -fxray-instrument       Generate XRay instrumentation sleds on function entry and exit
+  -fxray-link-deps        Tells clang to add the link dependencies for XRay.
+  -fxray-modes= <value>   List of modes to link in by default into XRay instrumented binaries.
   -fxray-never-instrument= <value>
-                          Filename defining the whitelist for imbuing the 'never instrument' XRay attribute.
+                          DEPRECATED: Filename defining the whitelist for imbuing the 'never instrument' XRay attribute.
   -fzvector               Enable System z vector language extension
   -F <value>              Add directory to framework include search path
   --gcc-toolchain=<value> Use the gcc toolchain at the given directory
+  -gcodeview-ghash        Emit type record hashes in a .debug$H section
   -gcodeview              Generate CodeView debug information
   -gdwarf-2               Generate source-level debug information with dwarf version 2
   -gdwarf-3               Generate source-level debug information with dwarf version 3
   -gdwarf-4               Generate source-level debug information with dwarf version 4
   -gdwarf-5               Generate source-level debug information with dwarf version 5
+  -gdwarf                 Generate source-level debug information with the default dwarf version
+  -gembed-source          Embed source text in DWARF debug sections
+  -gline-directives-only  Emit debug line info directives only
   -gline-tables-only      Emit debug line number tables only
   -gmodules               Generate debug info with external references to clang modules or precompiled headers
+  -gno-embed-source       Restore the default behavior of not embedding source text in DWARF debug sections
+  -gno-inline-line-tables Don't emit inline line tables
+  --gpu-max-threads-per-block=<value>
+                          Default max threads per block for kernel launch bounds for HIP
+  -gsplit-dwarf=<value>   Set DWARF fission mode to either 'split' or 'single'
   -gz=<value>             DWARF debug sections compression type
   -gz                     DWARF debug sections compression type
   -G <size>               Put objects of at most <size> bytes into small data section (MIPS / Hexagon)
   -g                      Generate source-level debug information
+  --help-hidden           Display help for hidden options
   -help                   Display available options
+  --hip-device-lib-path=<value>
+                          HIP device library path
+  --hip-device-lib=<value>
+                          HIP device library
+  --hip-link              Link clang-offload-bundler bundles for HIP
   -H                      Show header includes and nesting depth
   -I-                     Restrict all prior -I flags to double-quoted inclusion and remove current directory from include path
   -idirafter <value>      Add directory to AFTER include search path
@@ -424,17 +614,26 @@ OPTIONS:
   -iwithsysroot <directory>
                           Add directory to SYSTEM include search path, absolute paths are relative to -isysroot
   -I <dir>                Add directory to include search path
+  --libomptarget-nvptx-path=<value>
+                          Path to libomptarget-nvptx libraries
   -L <dir>                Add directory to library search path
   -mabicalls              Enable SVR4-style position-independent code (Mips only)
   -malign-double          Align doubles to two words in structs (x86 only)
   -mbackchain             Link stack frames through backchain on System Z
-  -mcrc                   Allow use of CRC instructions (ARM only)
+  -mbranch-protection=<value>
+                          Enforce targets of indirect branches and function returns
+  -mcmodel=medany         Equivalent to -mcmodel=medium, compatible with RISC-V gcc.
+  -mcmodel=medlow         Equivalent to -mcmodel=small, compatible with RISC-V gcc.
+  -mcmse                  Allow use of CMSE (Armv8-M Security Extensions)
+  -mcode-object-v3        Enable code object v3 (AMDGPU only)
+  -mcrc                   Allow use of CRC instructions (ARM/Mips only)
+  -mcumode                CU wavefront execution mode is used (AMDGPU only)
   -MD                     Write a depfile containing user and system headers
   -meabi <value>          Set EABI type, e.g. 4, 5 or gnu (default depends on triple)
   -membedded-data         Place constants in the .rodata section instead of the .sdata section even if they meet the -G <size> threshold (MIPS)
   -mexecute-only          Disallow generation of data access to code sections (ARM only)
   -mextern-sdata          Assume that externally defined data is in the small data if it meets the -G <size> threshold (MIPS)
-  -mfentry                Insert calls to fentry at function entry (x86 only)
+  -mfentry                Insert calls to fentry at function entry (x86/SystemZ only)
   -mfix-cortex-a53-835769 Workaround Cortex-A53 erratum 835769 (AArch64 only)
   -mfp32                  Use 32-bit floating point registers (MIPS only)
   -mfp64                  Use 64-bit floating point registers (MIPS only)
@@ -443,7 +642,6 @@ OPTIONS:
   -mglobal-merge          Enable merging of globals
   -mgpopt                 Use GP relative accesses for symbols known to be in a small data section (MIPS)
   -MG                     Add missing headers to depfile
-  -mhvx-double            Enable Hexagon Double Vector eXtensions
   -mhvx-length=<value>    Set Hexagon Vector Length
   -mhvx=<value>           Enable Hexagon Vector eXtensions
   -mhvx                   Enable Hexagon Vector eXtensions
@@ -451,21 +649,29 @@ OPTIONS:
   --migrate               Run the migrator
   -mincremental-linker-compatible
                           (integrated-as) Emit an object file which can be used with an incremental linker
+  -mindirect-jump=<value> Change indirect jump instructions to inhibit speculation
   -mios-version-min=<value>
                           Set iOS deployment target
   -MJ <value>             Write a compilation database entry per input
   -mllvm <value>          Additional arguments to forward to LLVM's option processing
   -mlocal-sdata           Extend the -G behaviour to object local data (MIPS)
   -mlong-calls            Generate branches with extended addressability, usually via indirect jumps.
+  -mlong-double-128       Force long double to be 128 bits
+  -mlong-double-64        Force long double to be 64 bits
+  -mlong-double-80        Force long double to be 80 bits, padded to 128 bits for storage
   -mmacosx-version-min=<value>
                           Set Mac OS X deployment target
   -mmadd4                 Enable the generation of 4-operand madd.s, madd.d and related instructions.
   -MMD                    Write a depfile containing user headers
+  -mmemops                Enable generation of memop instructions
   -mms-bitfields          Set the default structure layout to be compatible with the Microsoft compiler standard
   -mmsa                   Enable MSA ASE (MIPS only)
   -mmt                    Enable MT ASE (MIPS only)
   -MM                     Like -MMD, but also implies -E and writes to stdout by default
   -mno-abicalls           Disable SVR4-style position-independent code (Mips only)
+  -mno-code-object-v3     Disable code object v3 (AMDGPU only)
+  -mno-crc                Disallow use of CRC instructions (Mips only)
+  -mno-cumode             WGP wavefront execution mode is used (AMDGPU only)
   -mno-embedded-data      Do not place constants in the .rodata section instead of the .sdata if they meet the -G <size> threshold (MIPS)
   -mno-execute-only       Allow generation of data access to code sections (ARM only)
   -mno-extern-sdata       Do not assume that externally defined data is in the small data if it meets the -G <size> threshold (MIPS)
@@ -473,7 +679,6 @@ OPTIONS:
                           Don't workaround Cortex-A53 erratum 835769 (AArch64 only)
   -mno-global-merge       Disable merging of globals
   -mno-gpopt              Do not use GP relative accesses for symbols known to be in a small data section (MIPS)
-  -mno-hvx-double         Disable Hexagon Double Vector eXtensions
   -mno-hvx                Disable Hexagon Vector eXtensions
   -mno-implicit-float     Don't generate implicit floating point instructions
   -mno-incremental-linker-compatible
@@ -481,48 +686,79 @@ OPTIONS:
   -mno-local-sdata        Do not extend the -G behaviour to object local data (MIPS)
   -mno-long-calls         Restore the default behaviour of not generating long calls
   -mno-madd4              Disable the generation of 4-operand madd.s, madd.d and related instructions.
+  -mno-memops             Disable generation of memop instructions
   -mno-movt               Disallow use of movt/movw pairs (ARM only)
   -mno-ms-bitfields       Do not set the default structure layout to be compatible with the Microsoft compiler standard
   -mno-msa                Disable MSA ASE (MIPS only)
   -mno-mt                 Disable MT ASE (MIPS only)
   -mno-neg-immediates     Disallow converting instructions with negative immediates to their negation or inversion.
+  -mno-nvj                Disable generation of new-value jumps
+  -mno-nvs                Disable generation of new-value stores
+  -mno-outline            Disable function outlining (AArch64 only)
+  -mno-packets            Disable generation of instruction packets
+  -mno-relax              Disable linker relaxation
   -mno-restrict-it        Allow generation of deprecated IT blocks for ARMv8. It is off by default for ARMv8 Thumb mode
+  -mno-save-restore       Disable using library calls for save and restore
+  -mno-sram-ecc           Disable SRAM ECC (AMDGPU only)
+  -mno-stack-arg-probe    Disable stack probes which are enabled by default
+  -mno-tls-direct-seg-refs
+                          Disable direct TLS access through segment registers
   -mno-unaligned-access   Force all memory accesses to be aligned (AArch32/AArch64 only)
+  -mno-wavefrontsize64    Wavefront size 32 is used
   -mno-xnack              Disable XNACK (AMDGPU only)
   -mnocrc                 Disallow use of CRC instructions (ARM only)
+  -mnop-mcount            Generate mcount/__fentry__ calls as nops. To activate they need to be patched in.
+  -mnvj                   Enable generation of new-value jumps
+  -mnvs                   Enable generation of new-value stores
   -module-dependency-dir <value>
                           Directory to dump module dependencies to
   -module-file-info       Provide information about a particular module file
   -momit-leaf-frame-pointer
                           Omit frame pointer setup for leaf functions
+  -moutline               Enable function outlining (AArch64 only)
+  -mpacked-stack          Use packed stack layout (SystemZ only).
+  -mpackets               Enable generation of instruction packets
   -mpie-copy-relocations  Use copy relocations support for PIE builds
   -mprefer-vector-width=<value>
                           Specifies preferred vector width for auto-vectorization. Defaults to 'none' which allows target specific decisions.
   -MP                     Create phony target for each dependency (other than main file)
   -mqdsp6-compat          Enable hexagon-qdsp6 backward compatibility
   -MQ <value>             Specify name of main file output to quote in depfile
+  -mrecord-mcount         Generate a __mcount_loc section entry for each __fentry__ call.
   -mrelax-all             (integrated-as) Relax all machine instructions
+  -mrelax                 Enable linker relaxation
   -mrestrict-it           Disallow generation of deprecated IT blocks for ARMv8. It is on by default for ARMv8 Thumb mode.
   -mrtd                   Make StdCall calling convention the default
+  -msave-restore          Enable using library calls for save and restore
+  -msign-return-address=<value>
+                          Select return address signing scope
   -msoft-float            Use software floating point
+  -msram-ecc              Enable SRAM ECC (AMDGPU only)
   -mstack-alignment=<value>
                           Set the stack alignment
+  -mstack-arg-probe       Enable stack probes
   -mstack-probe-size=<value>
                           Set the stack probe size
   -mstackrealign          Force realign the stack at entry to every function
   -mthread-model <value>  The thread model to use, e.g. posix, single (posix by default)
-  -mtp=<value>            Read thread pointer from coprocessor register (ARM only)
+  -mtls-direct-seg-refs   Enable direct TLS access through segment registers (default)
+  -mtls-size=<value>      Specify bit size of immediate TLS offsets (AArch64 ELF only): 12 (for 4KB) | 24 (for 16MB, default) | 32 (for 4GB) | 48 (for 256TB, needs -mcmodel=large)
+  -mtp=<value>            Thread pointer access method (AArch32/AArch64 only)
   -MT <value>             Specify name of main file output in depfile
   -munaligned-access      Allow memory accesses to be unaligned (AArch32/AArch64 only)
   -MV                     Use NMake/Jom format for the depfile
+  -mwavefrontsize64       Wavefront size 64 is used
   -mxnack                 Enable XNACK (AMDGPU only)
   -M                      Like -MD, but also implies -E and writes to stdout by default
   --no-cuda-gpu-arch=<value>
                           Remove GPU architecture (e.g. sm_35) from the list of GPUs to compile for. 'all' resets the list to its default value.
+  --no-cuda-include-ptx=<value>
+                          Do not include PTX for the following GPU architecture (e.g. sm_35) or 'all'. May be specified more than once.
   --no-cuda-version-check Don't error out if the detected version of the CUDA install is too low for the requested CUDA gpu architecture.
   --no-system-header-prefix=<prefix>
                           Treat all #include paths starting with <prefix> as not including a system header.
   -nobuiltininc           Disable builtin #include directories
+  -nogpulib               Do not link device library for CUDA/HIP device compilation
   -nostdinc++             Disable standard #include directories for the C++ standard library
   -ObjC++                 Treat source input files as Objective-C++ inputs
   -objcmt-atomic-property Make migration to 'atomic' properties
@@ -560,16 +796,21 @@ OPTIONS:
   -pg                     Enable mcount instrumentation
   -pipe                   Use pipes between commands, when possible
   --precompile            Only precompile the input
+  -print-effective-triple Print the effective target triple
   -print-file-name=<file> Print the full library path of <file>
   -print-ivar-layout      Enable Objective-C Ivar layout bitmap print trace
   -print-libgcc-file-name Print the library path for the currently used compiler runtime library ("libgcc.a" or "libclang_rt.builtins.*.a")
   -print-prog-name=<name> Print the full program path of <name>
   -print-resource-dir     Print the resource directory pathname
   -print-search-dirs      Print the paths used for finding libraries and programs
+  -print-supported-cpus   Print supported cpu models for the given target (if target is not specified, it will print the supported cpus for the default target)
+  -print-target-triple    Print the normalized target triple
   -pthread                Support POSIX threads in generated code
   --ptxas-path=<value>    Path to ptxas (used for compiling CUDA code)
   -P                      Disable linemarker output in -E mode
+  -Qn                     Do not emit metadata containing compiler name and version
   -Qunused-arguments      Don't emit warning for unused driver arguments
+  -Qy                     Emit metadata containing compiler name and version
   -relocatable-pch        Whether to build a relocatable precompiled header
   -rewrite-legacy-objc    Rewrite Legacy Objective-C source to C++
   -rewrite-objc           Rewrite Objective-C source to C++
@@ -584,20 +825,26 @@ OPTIONS:
   -save-temps             Save intermediate compilation results
   -serialize-diagnostics <value>
                           Serialize compiler diagnostics to a file
+  -shared-libsan          Dynamically link the sanitizer runtime
+  -static-libsan          Statically link the sanitizer runtime
+  -static-openmp          Use the static host OpenMP runtime while linking.
   -std=<value>            Language standard to compile for
+  -stdlib++-isystem <directory>
+                          Use directory as the C++ standard library include path
   -stdlib=<value>         C++ standard library to use
   --system-header-prefix=<prefix>
                           Treat all #include paths starting with <prefix> as including a system header.
   -S                      Only run preprocess and compilation steps
   --target=<value>        Generate code for the given target
   -Tbss <addr>            Set starting address of BSS to <addr>
-  -Tdata <addr>           Set starting address of BSS to <addr>
+  -Tdata <addr>           Set starting address of DATA to <addr>
   -time                   Time individual commands
   -traditional-cpp        Enable some traditional CPP emulation
   -trigraphs              Process trigraph sequences
-  -Ttext <addr>           Set starting address of BSS to <addr>
+  -Ttext <addr>           Set starting address of TEXT to <addr>
   -T <script>             Specify <script> as linker script
   -undef                  undef all system defines
+  -unwindlib=<value>      Unwind library to use
   -U <macro>              Undefine macro <macro>
   --verify-debug-info     Verify the binary representation of debug output
   -verify-pch             Load and verify that a pre-compiled header file is not stale
@@ -617,7 +864,8 @@ OPTIONS:
   -Xcuda-fatbinary <arg>  Pass <arg> to fatbinary invocation
   -Xcuda-ptxas <arg>      Pass <arg> to the ptxas assembler
   -Xlinker <arg>          Pass <arg> to the linker
-  -Xopenmp-target=<arg>   Pass <arg> to the specified target offloading toolchain. The triple that identifies the toolchain must be provided after the equals sign.
+  -Xopenmp-target=<triple> <arg>
+                          Pass <arg> to the target offloading toolchain identified by <triple>.
   -Xopenmp-target <arg>   Pass <arg> to the target offloading toolchain.
   -Xpreprocessor <arg>    Pass <arg> to the preprocessor
   -x <language>           Treat subsequent input files as having type <language>

--- a/programl/Documentation/cmd/graph2nx.txt
+++ b/programl/Documentation/cmd/graph2nx.txt
@@ -1,10 +1,6 @@
 Convert a ProgramGraph to NetworkX.
 flags:
 
-programl/cmd/graph2nx.py:
-  --stdin_fmt: The format for stdin. One of {pb,pbtxt}
-    (default: 'pbtxt')
-
 absl.app:
   -?,--[no]help: show this help
     (default: 'false')
@@ -77,6 +73,12 @@ labm8.py.internal.labm8_logging:
     value given by --v.
     (default: '')
     (a comma separated list)
+
+programl.util.py.stdin_fmt:
+  --stdin_fmt: The type of input format to use. Valid options are: "pbtxt" which
+    reads a text format protocol buffer, "pb" which reads a binary format
+    protocol buffer, or "json" which reads a JSON format protocol buffer.
+    (default: 'pbtxt')
 
 absl.flags:
   --flagfile: Insert flag definitions from the given file into the command line.

--- a/programl/Documentation/cmd/inst2vec.txt
+++ b/programl/Documentation/cmd/inst2vec.txt
@@ -25,10 +25,6 @@ programl/cmd/inst2vec.py:
   --ir: The path of the IR file that was used to construct the graph. This is
     required to inline struct definitions. This argument may be omitted when
     struct definitions do not need to be inlined.
-  --stdin_fmt: The format for stdin. One of {pb,pbtxt}
-    (default: 'pbtxt')
-  --stdout_fmt: The format for stdout. One of {pb,pbtxt}
-    (default: 'pbtxt')
 
 absl.app:
   -?,--[no]help: show this help
@@ -102,6 +98,20 @@ labm8.py.internal.labm8_logging:
     value given by --v.
     (default: '')
     (a comma separated list)
+
+programl.util.py.stdin_fmt:
+  --stdin_fmt: The type of input format to use. Valid options are: "pbtxt" which
+    reads a text format protocol buffer, "pb" which reads a binary format
+    protocol buffer, or "json" which reads a JSON format protocol buffer.
+    (default: 'pbtxt')
+
+programl.util.py.stdout_fmt:
+  --stdout_fmt: The format of output. Valid options are: "pbtxt" for a text-
+    format protocol buffer, "pb" for a binary format protocol buffer, or "json"
+    for JSON. Text format protocol buffers are recommended for human-readable
+    output, binary-format for efficient and fast file storage, and JSON for
+    processing with third-party tools such as `jq`.
+    (default: 'pbtxt')
 
 absl.flags:
   --flagfile: Insert flag definitions from the given file into the command line.

--- a/programl/cmd/BUILD
+++ b/programl/cmd/BUILD
@@ -46,6 +46,7 @@ cc_binary(
     name = "clang2graph",
     srcs = ["clang2graph.cc"],
     copts = [
+        "-std=c++14",
         "-fno-rtti",
         "-DGOOGLE_PROTOBUF_NO_RTTI",
     ],
@@ -55,7 +56,7 @@ cc_binary(
         "//programl/ir/llvm",
         "//programl/proto:program_graph_cc",
         "//programl/proto:program_graph_options_cc",
-        "//third_party/llvm",
+        "@llvm//10.0.0",
     ],
 )
 
@@ -139,6 +140,7 @@ py_binary(
 cc_binary(
     name = "llvm2graph",
     srcs = ["llvm2graph.cc"],
+    copts = ["-std=c++14"],
     visibility = ["//visibility:public"],
     deps = [
         "//labm8/cpp:app",
@@ -150,7 +152,7 @@ cc_binary(
         "//programl/proto:program_graph_cc",
         "//programl/proto:program_graph_options_cc",
         "//programl/util:stdout_fmt",
-        "//third_party/llvm",
+        "@llvm//10.0.0",
     ],
 )
 

--- a/programl/cmd/clang2graph.cc
+++ b/programl/cmd/clang2graph.cc
@@ -25,6 +25,13 @@
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ExecutionEngine/ExecutionEngine.h"
 #include "llvm/ExecutionEngine/MCJIT.h"
+#include "llvm/ExecutionEngine/Orc/CompileUtils.h"
+#include "llvm/ExecutionEngine/Orc/ExecutionUtils.h"
+#include "llvm/ExecutionEngine/Orc/IRCompileLayer.h"
+#include "llvm/ExecutionEngine/Orc/RTDyldObjectLinkingLayer.h"
+#include "llvm/ExecutionEngine/SectionMemoryManager.h"
+#include "llvm/IR/DataLayout.h"
+#include "llvm/IR/Mangler.h"
 #include "llvm/IR/Module.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/Host.h"
@@ -32,6 +39,7 @@
 #include "llvm/Support/Path.h"
 #include "llvm/Support/TargetSelect.h"
 #include "llvm/Support/raw_ostream.h"
+#include "llvm/Target/TargetMachine.h"
 
 #include "labm8/cpp/status.h"
 
@@ -115,11 +123,9 @@ int main(int argc, const char **argv, char *const *envp) {
   }
 
   // Initialize a compiler invocation object from the clang (-cc1) arguments.
-  const driver::ArgStringList &CCArgs = Cmd.getArguments();
+  const llvm::opt::ArgStringList &CCArgs = Cmd.getArguments();
   std::unique_ptr<CompilerInvocation> CI(new CompilerInvocation);
-  CompilerInvocation::CreateFromArgs(
-      *CI, const_cast<const char **>(CCArgs.data()),
-      const_cast<const char **>(CCArgs.data()) + CCArgs.size(), Diags);
+  CompilerInvocation::CreateFromArgs(*CI, CCArgs, Diags);
 
   // Show the invocation, with -v.
   if (CI->getHeaderSearchOpts().Verbose) {

--- a/programl/install.sh
+++ b/programl/install.sh
@@ -40,9 +40,9 @@ BINARIES=(
 )
 
 if [[ $(uname) == Darwin ]]; then
-  LLVM_LIBS="$(DataPath llvm_mac/lib)"
+  LLVM_LIBS="$(DataPath clang-llvm-10.0.0-x86_64-apple-darwin/lib)"
 else
-  LLVM_LIBS="$(DataPath llvm_linux/lib)"
+  LLVM_LIBS="$(DataPath clang-llvm-10.0.0-x86_64-linux-gnu-ubuntu-18.04/lib)"
 fi
 
 main() {

--- a/programl/ir/llvm/BUILD
+++ b/programl/ir/llvm/BUILD
@@ -22,10 +22,10 @@ cc_library(
     hdrs = ["clang.h"],
     data = select({
         "//:darwin": [
-            "@llvm_mac//:clang++",
+            "@clang-llvm-10.0.0-x86_64-apple-darwin//:clang++",
         ],
         "//conditions:default": [
-            "@llvm_linux//:clang++",
+            "@clang-llvm-10.0.0-x86_64-linux-gnu-ubuntu-18.04//:clang++",
         ],
     }),
     visibility = ["//visibility:public"],
@@ -88,6 +88,7 @@ cc_library(
     name = "llvm",
     srcs = ["llvm.cc"],
     hdrs = ["llvm.h"],
+    copts = ["-std=c++14"],
     visibility = ["//visibility:public"],
     deps = [
         "//labm8/cpp:status",
@@ -95,6 +96,6 @@ cc_library(
         "//programl/ir/llvm/internal:program_graph_builder_pass",
         "//programl/proto:program_graph_cc",
         "//programl/proto:program_graph_options_cc",
-        "//third_party/llvm",
+        "@llvm//10.0.0",
     ],
 )

--- a/programl/ir/llvm/clang.cc
+++ b/programl/ir/llvm/clang.cc
@@ -27,9 +27,10 @@ namespace ir {
 namespace llvm {
 
 #ifdef __APPLE__
-const char* kClangPath = "llvm_mac/bin/clang++";
+const char* kClangPath = "clang-llvm-10.0.0-x86_64-apple-darwin/bin/clang++";
 #else
-const char* kClangPath = "llvm_linux/bin/clang++";
+const char* kClangPath =
+    "clang-llvm-10.0.0-x86_64-linux-gnu-ubuntu-18.04/bin/clang++";
 #endif
 
 Status Clang::Compile(const string& src, IrList* irs) const {

--- a/programl/ir/llvm/internal/BUILD
+++ b/programl/ir/llvm/internal/BUILD
@@ -32,6 +32,7 @@ cc_library(
     name = "program_graph_builder",
     srcs = ["program_graph_builder.cc"],
     hdrs = ["program_graph_builder.h"],
+    copts = ["-std=c++14"],
     deps = [
         ":text_encoder",
         "//labm8/cpp:status_macros",
@@ -41,9 +42,9 @@ cc_library(
         "//programl/graph:program_graph_builder",
         "//programl/proto:program_graph_cc",
         "//programl/proto:program_graph_options_cc",
-        "//third_party/llvm",
         "@com_google_absl//absl/container:flat_hash_map",
         "@com_google_absl//absl/container:flat_hash_set",
+        "@llvm//10.0.0",
     ],
 )
 
@@ -52,6 +53,7 @@ cc_library(
     srcs = ["program_graph_builder_pass.cc"],
     hdrs = ["program_graph_builder_pass.h"],
     copts = [
+        "-std=c++14",
         "-fno-rtti",
         "-DGOOGLE_PROTOBUF_NO_RTTI",
     ],
@@ -60,7 +62,7 @@ cc_library(
         ":program_graph_builder",
         "//labm8/cpp:statusor",
         "//programl/proto:program_graph_options_cc",
-        "//third_party/llvm",
+        "@llvm//10.0.0",
     ],
 )
 
@@ -68,10 +70,11 @@ cc_library(
     name = "text_encoder",
     srcs = ["text_encoder.cc"],
     hdrs = ["text_encoder.h"],
+    copts = ["-std=c++14"],
     deps = [
         "//labm8/cpp:logging",
         "//labm8/cpp:string",
-        "//third_party/llvm",
         "@com_google_absl//absl/container:flat_hash_map",
+        "@llvm//10.0.0",
     ],
 )

--- a/programl/ir/llvm/internal/program_graph_builder.cc
+++ b/programl/ir/llvm/internal/program_graph_builder.cc
@@ -389,7 +389,7 @@ StatusOr<ProgramGraph> ProgramGraphBuilder::Build(
     if (function.hasProfileData()) {
       auto profileCount = function.getEntryCount();
       Feature feature;
-      feature.mutable_int64_list()->add_value(profileCount.getValue());
+      feature.mutable_int64_list()->add_value(profileCount.getCount());
       functionMessage->mutable_features()->mutable_feature()->insert(
           {"llvm_profile_entry_count", feature});
     }

--- a/programl/ir/llvm/internal/program_graph_builder_pass.h
+++ b/programl/ir/llvm/internal/program_graph_builder_pass.h
@@ -19,6 +19,7 @@
 
 #include "labm8/cpp/statusor.h"
 #include "llvm/IR/Module.h"
+#include "llvm/Pass.h"
 #include "programl/ir/llvm/internal/program_graph_builder.h"
 #include "programl/proto/program_graph.pb.h"
 #include "programl/proto/program_graph_options.pb.h"

--- a/programl/ir/llvm/py/BUILD
+++ b/programl/ir/llvm/py/BUILD
@@ -54,6 +54,6 @@ cc_binary(
         "//programl/ir/llvm",
         "//programl/proto:program_graph_cc",
         "//programl/proto:program_graph_options_cc",
-        "//third_party/llvm",
+        "@llvm//10.0.0",
     ],
 )

--- a/programl/test/data/BUILD
+++ b/programl/test/data/BUILD
@@ -2054,15 +2054,15 @@ genrule(
         "for f in $(locations :llvm_ir); do" +
         "    basename=$$(basename $$f); " +
         "    out=$(@D)/llvm_ir_graphs/$${basename%.ll}.ProgramGraph.pb;" +
-        "    LD_LIBRARY_PATH=$(location @llvm_linux//:libdir):$(location @llvm_mac//:libdir) $(location //programl/cmd:llvm2graph) --stdout_fmt=pb <$$f --stdout_fmt=pb >$$out;" +
+        "    LD_LIBRARY_PATH=$(location @clang-llvm-10.0.0-x86_64-linux-gnu-ubuntu-18.04//:libdir):$(location @clang-llvm-10.0.0-x86_64-apple-darwin//:libdir) $(location //programl/cmd:llvm2graph) --stdout_fmt=pb <$$f --stdout_fmt=pb >$$out;" +
         "done && " +
         "$(location //programl/cmd:inst2vec) --directory=$(@D)/llvm_ir_graphs"
     ),
     tools = [
         "//programl/cmd:inst2vec",
         "//programl/cmd:llvm2graph",
-        "@llvm_linux//:libdir",
-        "@llvm_mac//:libdir",
+        "@clang-llvm-10.0.0-x86_64-apple-darwin//:libdir",
+        "@clang-llvm-10.0.0-x86_64-linux-gnu-ubuntu-18.04//:libdir",
     ],
 )
 


### PR DESCRIPTION
This upgrades the version of LLVM that ProGraML uses from 6.0.0 to
10.0.0. For the most part, this requires little changes to the
code. Only a few APIs have moved around and most things work the
same.
